### PR TITLE
Administrator-only operations

### DIFF
--- a/src/main/java/cloud/fogbow/ms/Main.java
+++ b/src/main/java/cloud/fogbow/ms/Main.java
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Component;
 import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
 import cloud.fogbow.common.exceptions.FatalErrorException;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.ServiceAsymmetricKeysHolder;
 import cloud.fogbow.ms.core.ApplicationFacade;
 import cloud.fogbow.ms.core.MembershipService;
 import cloud.fogbow.ms.core.PluginInstantiator;
 import cloud.fogbow.ms.core.PropertiesHolder;
+import cloud.fogbow.ms.core.authorization.AdminOperation;
 
 @Component
 public class Main implements ApplicationRunner {
@@ -26,8 +28,11 @@ public class Main implements ApplicationRunner {
             ServiceAsymmetricKeysHolder.getInstance().setPublicKeyFilePath(publicKeyFilePath);
             ServiceAsymmetricKeysHolder.getInstance().setPrivateKeyFilePath(privateKeyFilePath);
             
+            AuthorizationPlugin<AdminOperation> authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
             MembershipService membershipService = PluginInstantiator.getMembershipService();
+            
             ApplicationFacade.getInstance().setMembershipService(membershipService);
+            ApplicationFacade.getInstance().setAuthorizationPlugin(authorizationPlugin);
             
         } catch (FatalErrorException errorException) {
             LOGGER.fatal(errorException.getMessage(), errorException);

--- a/src/main/java/cloud/fogbow/ms/Main.java
+++ b/src/main/java/cloud/fogbow/ms/Main.java
@@ -14,7 +14,7 @@ import cloud.fogbow.ms.core.ApplicationFacade;
 import cloud.fogbow.ms.core.MembershipService;
 import cloud.fogbow.ms.core.PluginInstantiator;
 import cloud.fogbow.ms.core.PropertiesHolder;
-import cloud.fogbow.ms.core.authorization.AdminOperation;
+import cloud.fogbow.ms.core.authorization.MsOperation;
 
 @Component
 public class Main implements ApplicationRunner {
@@ -28,7 +28,7 @@ public class Main implements ApplicationRunner {
             ServiceAsymmetricKeysHolder.getInstance().setPublicKeyFilePath(publicKeyFilePath);
             ServiceAsymmetricKeysHolder.getInstance().setPrivateKeyFilePath(privateKeyFilePath);
             
-            AuthorizationPlugin<AdminOperation> authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
+            AuthorizationPlugin<MsOperation> authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
             MembershipService membershipService = PluginInstantiator.getMembershipService();
             
             ApplicationFacade.getInstance().setMembershipService(membershipService);

--- a/src/main/java/cloud/fogbow/ms/api/http/MsExceptionToHttpErrorConditionTranslator.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/MsExceptionToHttpErrorConditionTranslator.java
@@ -1,0 +1,9 @@
+package cloud.fogbow.ms.api.http;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import cloud.fogbow.common.http.FogbowExceptionToHttpErrorConditionTranslator;
+
+@ControllerAdvice
+public class MsExceptionToHttpErrorConditionTranslator extends FogbowExceptionToHttpErrorConditionTranslator {
+
+}

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ms.api.http.request;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.ms.api.http.CommonKeys;
+import cloud.fogbow.ms.api.parameters.Provider;
 import cloud.fogbow.ms.constants.SystemConstants;
 import cloud.fogbow.ms.core.ApplicationFacade;
 import io.swagger.annotations.ApiParam;
@@ -21,6 +23,7 @@ import io.swagger.annotations.ApiParam;
 public class Admin {
     public static final String ADMIN_ENDPOINT = SystemConstants.SERVICE_BASE_ENDPOINT + "admin";
     public static final String RELOAD_ENDPOINT = ADMIN_ENDPOINT + "/reload";
+    public static final String ADD_PROVIDER_ENDPOINT = ADMIN_ENDPOINT + "/addprovider";
 	
     // TODO documentation
     @RequestMapping(value = "/reload", method = RequestMethod.POST)
@@ -30,4 +33,15 @@ public class Admin {
         ApplicationFacade.getInstance().reload(systemUserToken);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+    
+    // TODO documentation
+    @RequestMapping(value = "/addprovider", method = RequestMethod.POST)
+    public ResponseEntity<Boolean> addProvider(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().addProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
 }

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -44,4 +44,24 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
+    // TODO documentation
+    @RequestMapping(value = "/addtarget", method = RequestMethod.POST)
+    public ResponseEntity<Boolean> addTarget(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().addTargetProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
+    // TODO documentation
+    @RequestMapping(value = "/addrequester", method = RequestMethod.POST)
+    public ResponseEntity<Boolean> addRequester(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().addRequesterProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
 }

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -12,20 +12,24 @@ import org.springframework.web.bind.annotation.RestController;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.ms.api.http.CommonKeys;
 import cloud.fogbow.ms.api.parameters.Provider;
+import cloud.fogbow.ms.constants.ApiDocumentation;
 import cloud.fogbow.ms.constants.SystemConstants;
 import cloud.fogbow.ms.core.ApplicationFacade;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
 @CrossOrigin
 @RestController
 @RequestMapping(value = Admin.ADMIN_ENDPOINT)
-// TODO documentation
+@Api(description = ApiDocumentation.Admin.API)
 public class Admin {
     public static final String ADMIN_ENDPOINT = SystemConstants.SERVICE_BASE_ENDPOINT + "admin";
+    // TODO use these endpoint values
     public static final String RELOAD_ENDPOINT = ADMIN_ENDPOINT + "/reload";
-    public static final String ADD_PROVIDER_ENDPOINT = ADMIN_ENDPOINT + "/addprovider";
+    public static final String ADD_PROVIDER_ENDPOINT = ADMIN_ENDPOINT + "/provider";
 	
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.RELOAD)
     @RequestMapping(value = "/reload", method = RequestMethod.POST)
     public ResponseEntity<Boolean> reload(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
@@ -34,7 +38,7 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.ADD_PROVIDER)
     @RequestMapping(value = "/provider", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
@@ -44,7 +48,7 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.REMOVE_PROVIDER)
     @RequestMapping(value = "/provider", method = RequestMethod.DELETE)
     public ResponseEntity<Boolean> removeProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
@@ -54,7 +58,7 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.ADD_TARGET)
     @RequestMapping(value = "/target", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addTarget(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
@@ -64,7 +68,7 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.ADD_REQUESTER)
     @RequestMapping(value = "/requester", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addRequester(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
@@ -74,18 +78,17 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.REMOVE_TARGET)
     @RequestMapping(value = "/target", method = RequestMethod.DELETE)
     public ResponseEntity<Boolean> removeTarget(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
     				@RequestBody Provider provider) throws FogbowException {
     	ApplicationFacade.getInstance().removeTargetProvider(systemUserToken, provider.getProvider());
-    	// ApplicationFacade.getInstance().addTargetProvider(systemUserToken, provider.getProvider());
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    // TODO documentation
+    @ApiOperation(value = ApiDocumentation.Admin.REMOVE_REQUESTER)
     @RequestMapping(value = "/requester", method = RequestMethod.DELETE)
     public ResponseEntity<Boolean> removeRequester(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -1,0 +1,33 @@
+package cloud.fogbow.ms.api.http.request;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.ms.api.http.CommonKeys;
+import cloud.fogbow.ms.constants.SystemConstants;
+import cloud.fogbow.ms.core.ApplicationFacade;
+import io.swagger.annotations.ApiParam;
+
+@CrossOrigin
+@RestController
+@RequestMapping(value = Admin.ADMIN_ENDPOINT)
+// TODO documentation
+public class Admin {
+    public static final String ADMIN_ENDPOINT = SystemConstants.SERVICE_BASE_ENDPOINT + "admin";
+    public static final String RELOAD_ENDPOINT = ADMIN_ENDPOINT + "/reload";
+	
+    // TODO documentation
+    @RequestMapping(value = "/reload", method = RequestMethod.POST)
+    public ResponseEntity<Boolean> reload(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken) throws FogbowException {
+        ApplicationFacade.getInstance().reload(systemUserToken);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.ms.api.http.CommonKeys;
 import cloud.fogbow.ms.api.parameters.Provider;
+import cloud.fogbow.ms.api.parameters.Service;
 import cloud.fogbow.ms.constants.ApiDocumentation;
 import cloud.fogbow.ms.constants.SystemConstants;
 import cloud.fogbow.ms.core.ApplicationFacade;
@@ -35,6 +36,16 @@ public class Admin {
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken) throws FogbowException {
         ApplicationFacade.getInstance().reload(systemUserToken);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
+    @ApiOperation(value = ApiDocumentation.Admin.SERVICE)
+    @RequestMapping(value = "/service", method = RequestMethod.POST)
+    public ResponseEntity<Boolean> service(
+                    @ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+                    @RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY)String systemUserToken,
+                    @RequestBody Service service) throws FogbowException {
+        ApplicationFacade.getInstance().updateMembershipService(systemUserToken, service.getClassName());
         return new ResponseEntity<>(HttpStatus.OK);
     }
     

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -35,12 +35,22 @@ public class Admin {
     }
     
     // TODO documentation
-    @RequestMapping(value = "/addprovider", method = RequestMethod.POST)
+    @RequestMapping(value = "/provider", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
     				@RequestBody Provider provider) throws FogbowException {
     	ApplicationFacade.getInstance().addProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
+    // TODO documentation
+    @RequestMapping(value = "/provider", method = RequestMethod.DELETE)
+    public ResponseEntity<Boolean> removeProvider(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().removeProvider(systemUserToken, provider.getProvider());
         return new ResponseEntity<>(HttpStatus.OK);
     }
     

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.ms.api.http.CommonKeys;
 import cloud.fogbow.ms.api.parameters.Provider;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.api.parameters.Service;
 import cloud.fogbow.ms.constants.ApiDocumentation;
 import cloud.fogbow.ms.constants.SystemConstants;
@@ -24,6 +25,7 @@ import io.swagger.annotations.ApiParam;
 @RestController
 @RequestMapping(value = Admin.ADMIN_ENDPOINT)
 @Api(description = ApiDocumentation.Admin.API)
+// TODO add documentation for parameters
 public class Admin {
     public static final String ADMIN_ENDPOINT = SystemConstants.SERVICE_BASE_ENDPOINT + "admin";
     // TODO use these endpoint values
@@ -54,8 +56,8 @@ public class Admin {
     public ResponseEntity<Boolean> addProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
-    				@RequestBody Provider provider) throws FogbowException {
-    	ApplicationFacade.getInstance().addProvider(systemUserToken, provider.getProvider());
+    				@RequestBody ProviderPermission provider) throws FogbowException {
+        ApplicationFacade.getInstance().addProvider(systemUserToken, provider.getProvider(), provider.getTarget(), provider.getRequester());
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
@@ -69,43 +71,13 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
-    @ApiOperation(value = ApiDocumentation.Admin.ADD_TARGET)
-    @RequestMapping(value = "/target", method = RequestMethod.POST)
-    public ResponseEntity<Boolean> addTarget(
-    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
-    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
-    				@RequestBody Provider provider) throws FogbowException {
-    	ApplicationFacade.getInstance().addTargetProvider(systemUserToken, provider.getProvider());
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-    
-    @ApiOperation(value = ApiDocumentation.Admin.ADD_REQUESTER)
-    @RequestMapping(value = "/requester", method = RequestMethod.POST)
-    public ResponseEntity<Boolean> addRequester(
-    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
-    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
-    				@RequestBody Provider provider) throws FogbowException {
-    	ApplicationFacade.getInstance().addRequesterProvider(systemUserToken, provider.getProvider());
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-    
-    @ApiOperation(value = ApiDocumentation.Admin.REMOVE_TARGET)
-    @RequestMapping(value = "/target", method = RequestMethod.DELETE)
-    public ResponseEntity<Boolean> removeTarget(
-    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
-    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
-    				@RequestBody Provider provider) throws FogbowException {
-    	ApplicationFacade.getInstance().removeTargetProvider(systemUserToken, provider.getProvider());
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-    
-    @ApiOperation(value = ApiDocumentation.Admin.REMOVE_REQUESTER)
-    @RequestMapping(value = "/requester", method = RequestMethod.DELETE)
-    public ResponseEntity<Boolean> removeRequester(
-    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
-    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
-    				@RequestBody Provider provider) throws FogbowException {
-    	ApplicationFacade.getInstance().removeRequesterProvider(systemUserToken, provider.getProvider());
+    @ApiOperation(value = ApiDocumentation.Admin.UPDATE_PROVIDER)
+    @RequestMapping(value = "/provider", method = RequestMethod.PUT)
+    public ResponseEntity<Boolean> updateProvider(
+                    @ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+                    @RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+                    @RequestBody ProviderPermission provider) throws FogbowException {
+        ApplicationFacade.getInstance().updateProvider(systemUserToken, provider.getProvider(), provider.getTarget(), provider.getRequester());
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -57,7 +57,7 @@ public class Admin {
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
     				@RequestBody ProviderPermission provider) throws FogbowException {
-        ApplicationFacade.getInstance().addProvider(systemUserToken, provider.getProvider(), provider.getTarget(), provider.getRequester());
+        ApplicationFacade.getInstance().addProvider(systemUserToken, provider);
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
@@ -77,7 +77,7 @@ public class Admin {
                     @ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
                     @RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
                     @RequestBody ProviderPermission provider) throws FogbowException {
-        ApplicationFacade.getInstance().updateProvider(systemUserToken, provider.getProvider(), provider.getTarget(), provider.getRequester());
+        ApplicationFacade.getInstance().updateProvider(systemUserToken, provider);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -45,7 +45,7 @@ public class Admin {
     }
     
     // TODO documentation
-    @RequestMapping(value = "/addtarget", method = RequestMethod.POST)
+    @RequestMapping(value = "/target", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addTarget(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
@@ -55,7 +55,7 @@ public class Admin {
     }
     
     // TODO documentation
-    @RequestMapping(value = "/addrequester", method = RequestMethod.POST)
+    @RequestMapping(value = "/requester", method = RequestMethod.POST)
     public ResponseEntity<Boolean> addRequester(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
@@ -64,4 +64,24 @@ public class Admin {
         return new ResponseEntity<>(HttpStatus.OK);
     }
     
+    // TODO documentation
+    @RequestMapping(value = "/target", method = RequestMethod.DELETE)
+    public ResponseEntity<Boolean> removeTarget(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().removeTargetProvider(systemUserToken, provider.getProvider());
+    	// ApplicationFacade.getInstance().addTargetProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
+    // TODO documentation
+    @RequestMapping(value = "/requester", method = RequestMethod.DELETE)
+    public ResponseEntity<Boolean> removeRequester(
+    				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
+    				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
+    				@RequestBody Provider provider) throws FogbowException {
+    	ApplicationFacade.getInstance().removeRequesterProvider(systemUserToken, provider.getProvider());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
+++ b/src/main/java/cloud/fogbow/ms/api/http/request/Admin.java
@@ -28,12 +28,12 @@ import io.swagger.annotations.ApiParam;
 // TODO add documentation for parameters
 public class Admin {
     public static final String ADMIN_ENDPOINT = SystemConstants.SERVICE_BASE_ENDPOINT + "admin";
-    // TODO use these endpoint values
-    public static final String RELOAD_ENDPOINT = ADMIN_ENDPOINT + "/reload";
-    public static final String ADD_PROVIDER_ENDPOINT = ADMIN_ENDPOINT + "/provider";
+    public static final String RELOAD_ENDPOINT = "/reload";
+    public static final String SERVICE_ENDPOINT = "/service";
+    public static final String PROVIDER_ENDPOINT = "/provider";
 	
     @ApiOperation(value = ApiDocumentation.Admin.RELOAD)
-    @RequestMapping(value = "/reload", method = RequestMethod.POST)
+    @RequestMapping(value = RELOAD_ENDPOINT, method = RequestMethod.POST)
     public ResponseEntity<Boolean> reload(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken) throws FogbowException {
@@ -42,7 +42,7 @@ public class Admin {
     }
     
     @ApiOperation(value = ApiDocumentation.Admin.SERVICE)
-    @RequestMapping(value = "/service", method = RequestMethod.POST)
+    @RequestMapping(value = SERVICE_ENDPOINT, method = RequestMethod.POST)
     public ResponseEntity<Boolean> service(
                     @ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
                     @RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY)String systemUserToken,
@@ -52,7 +52,7 @@ public class Admin {
     }
     
     @ApiOperation(value = ApiDocumentation.Admin.ADD_PROVIDER)
-    @RequestMapping(value = "/provider", method = RequestMethod.POST)
+    @RequestMapping(value = PROVIDER_ENDPOINT, method = RequestMethod.POST)
     public ResponseEntity<Boolean> addProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
@@ -62,7 +62,7 @@ public class Admin {
     }
     
     @ApiOperation(value = ApiDocumentation.Admin.REMOVE_PROVIDER)
-    @RequestMapping(value = "/provider", method = RequestMethod.DELETE)
+    @RequestMapping(value = PROVIDER_ENDPOINT, method = RequestMethod.DELETE)
     public ResponseEntity<Boolean> removeProvider(
     				@ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
     				@RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,
@@ -72,7 +72,7 @@ public class Admin {
     }
     
     @ApiOperation(value = ApiDocumentation.Admin.UPDATE_PROVIDER)
-    @RequestMapping(value = "/provider", method = RequestMethod.PUT)
+    @RequestMapping(value = PROVIDER_ENDPOINT, method = RequestMethod.PUT)
     public ResponseEntity<Boolean> updateProvider(
                     @ApiParam(value = cloud.fogbow.common.constants.ApiDocumentation.Token.SYSTEM_USER_TOKEN)
                     @RequestHeader(required = false, value = CommonKeys.SYSTEM_USER_TOKEN_HEADER_KEY) String systemUserToken,

--- a/src/main/java/cloud/fogbow/ms/api/parameters/ProviderPermission.java
+++ b/src/main/java/cloud/fogbow/ms/api/parameters/ProviderPermission.java
@@ -5,15 +5,25 @@ public class ProviderPermission {
     private boolean target;
     private boolean requester;
     
+    public ProviderPermission() {
+        
+    }
+    
+    public ProviderPermission(String provider, boolean target, boolean requester) {
+        this.provider = provider;
+        this.target = target;
+        this.requester = requester;
+    }
+    
     public String getProvider() {
         return provider;
     }
     
-    public boolean getTarget() {
+    public boolean isTarget() {
         return target;
     }
     
-    public boolean getRequester() {
+    public boolean isRequester() {
         return requester;
     }
 }

--- a/src/main/java/cloud/fogbow/ms/api/parameters/ProviderPermission.java
+++ b/src/main/java/cloud/fogbow/ms/api/parameters/ProviderPermission.java
@@ -1,0 +1,19 @@
+package cloud.fogbow.ms.api.parameters;
+
+public class ProviderPermission {
+    private String provider;
+    private boolean target;
+    private boolean requester;
+    
+    public String getProvider() {
+        return provider;
+    }
+    
+    public boolean getTarget() {
+        return target;
+    }
+    
+    public boolean getRequester() {
+        return requester;
+    }
+}

--- a/src/main/java/cloud/fogbow/ms/api/parameters/Service.java
+++ b/src/main/java/cloud/fogbow/ms/api/parameters/Service.java
@@ -1,0 +1,9 @@
+package cloud.fogbow.ms.api.parameters;
+
+public class Service {
+    private String className;
+    
+    public String getClassName() {
+        return className;
+    }
+}

--- a/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
@@ -40,6 +40,7 @@ public class ApiDocumentation {
 				+ "to authorized operations from other providers";
 		public static final String REMOVE_REQUESTER = "Removes given provider from the list of requesters, used by the MembershipService "
 				+ "to authorized operations from other providers";
+		public static final String SERVICE = "Changes membership service plugin to the given class name";
     	
     }
 }

--- a/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
@@ -27,4 +27,19 @@ public class ApiDocumentation {
         public static final String TARGET_OPERATION = "States whether the local provider is allowed to perform operations in the given provider.";
     }
 
+    public static class Admin {
+    	public static final String API = "Manages admin-only operations";
+		public static final String RELOAD = "Reloads service configuration.";
+		public static final String ADD_PROVIDER = "Adds given provider to the list of known providers.";
+		public static final String REMOVE_PROVIDER = "Removes given provider from all the lists of providers kept by the service.";
+		public static final String ADD_TARGET = "Adds given provider to the list of targets, used by the MembershipService "
+				+ "to authorize remote operations.";
+		public static final String REMOVE_TARGET = "Removes given provider from the list of targets, used by the MembershipService "
+				+ "to authorize remote operations."; 
+		public static final String ADD_REQUESTER = "Adds given provider to the list of requesters, used by the MembershipService "
+				+ "to authorized operations from other providers";
+		public static final String REMOVE_REQUESTER = "Removes given provider from the list of requesters, used by the MembershipService "
+				+ "to authorized operations from other providers";
+    	
+    }
 }

--- a/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
@@ -33,6 +33,6 @@ public class ApiDocumentation {
 		public static final String ADD_PROVIDER = "Adds given provider to the list of known providers.";
 		public static final String REMOVE_PROVIDER = "Removes given provider from all the lists of providers kept by the service.";
 		public static final String UPDATE_PROVIDER = "Updates permission information for the given provider.";
-		public static final String SERVICE = "Changes membership service plugin to the given class name";
+		public static final String SERVICE = "Changes membership service plugin to the given class name.";
     }
 }

--- a/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ApiDocumentation.java
@@ -32,15 +32,7 @@ public class ApiDocumentation {
 		public static final String RELOAD = "Reloads service configuration.";
 		public static final String ADD_PROVIDER = "Adds given provider to the list of known providers.";
 		public static final String REMOVE_PROVIDER = "Removes given provider from all the lists of providers kept by the service.";
-		public static final String ADD_TARGET = "Adds given provider to the list of targets, used by the MembershipService "
-				+ "to authorize remote operations.";
-		public static final String REMOVE_TARGET = "Removes given provider from the list of targets, used by the MembershipService "
-				+ "to authorize remote operations."; 
-		public static final String ADD_REQUESTER = "Adds given provider to the list of requesters, used by the MembershipService "
-				+ "to authorized operations from other providers";
-		public static final String REMOVE_REQUESTER = "Removes given provider from the list of requesters, used by the MembershipService "
-				+ "to authorized operations from other providers";
+		public static final String UPDATE_PROVIDER = "Updates permission information for the given provider.";
 		public static final String SERVICE = "Changes membership service plugin to the given class name";
-    	
     }
 }

--- a/src/main/java/cloud/fogbow/ms/constants/ConfigurationPropertyKeys.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ConfigurationPropertyKeys.java
@@ -5,14 +5,12 @@ public class ConfigurationPropertyKeys {
     public static final String AS_PORT_KEY = "as_port";
     public static final String AS_URL_KEY = "as_url";
     public static final String AUTHORIZATION_PLUGIN_CLASS_KEY = "authorization_plugin_class";
-    public static final String AUTHORIZED_TARGET_MEMBERS_LIST_KEY = "authorized_target_members";
-    public static final String AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY = "authorized_requester_members";
+    public static final String TARGET_MEMBERS_LIST_KEY = "target_members";
+    public static final String REQUESTER_MEMBERS_LIST_KEY = "requester_members";
     public static final String BUILD_NUMBER_KEY = "build_number";
     public static final String DEFAULT_ROLE_KEY = "default_role";
     public static final String MEMBERS_LIST_KEY = "members_list";
     public static final String MEMBERSHIP_SERVICE_CLASS_KEY = "membership_service_plugin_class";
-    public static final String NOT_AUTHORIZED_TARGET_MEMBERS_LIST_KEY = "not_authorized_target_members";
-    public static final String NOT_AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY = "not_authorized_requester_members";
     public static final String PROVIDER_ID_KEY = "provider_id";
     public static final String RAS_PORT_KEY = "ras_port";
     public static final String RAS_URL_KEY = "ras_url";

--- a/src/main/java/cloud/fogbow/ms/constants/ConfigurationPropertyKeys.java
+++ b/src/main/java/cloud/fogbow/ms/constants/ConfigurationPropertyKeys.java
@@ -1,6 +1,7 @@
 package cloud.fogbow.ms.constants;
 
 public class ConfigurationPropertyKeys {
+	public static final String ADMINS_IDS = "admins_ids";
     public static final String AS_PORT_KEY = "as_port";
     public static final String AS_URL_KEY = "as_url";
     public static final String AUTHORIZATION_PLUGIN_CLASS_KEY = "authorization_plugin_class";

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     	public static final String ADDING_NEW_PROVIDER = "Adding provider: %s";
     	public static final String ADDING_REQUESTER_PROVIDER = "Adding requester: %s";
     	public static final String ADDING_TARGET_PROVIDER = "Adding target: %s";
+    	public static final String CHANGING_MEMBERSHIP_PLUGIN = "Changing membership plugin to: %s";
     	public static final String GET_PUBLIC_KEY = "Get public key received.";
         public static final String INTERNAL_SERVER_ERROR = "Internal server error.";
         public static final String RELOADING_AUTHORIZATION_PLUGIN = "Reloading authorization plugin.";

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -7,14 +7,28 @@ public class Messages {
         public static final String INVALID_MEMBER_NAME = "Invalid member name in configuration.";
         public static final String MEMBER_IS_NOT_REQUESTER = "Member is not requester.";
         public static final String MEMBER_IS_NOT_TARGET = "Member is not target.";
+        public static final String NO_ADMIN_SPECIFIED = "No admin specified in the configuration file.";
         public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member.";
         public static final String PROVIDER_IS_ALREADY_A_REQUESTER = "Provider is already a requester.";
         public static final String PROVIDER_IS_ALREADY_A_TARGET = "Provider is already a target.";
         public static final String UNABLE_TO_FIND_CLASS_S = "Unable to find class %s.";
+		public static final String USER_IS_NOT_ADMIN = "Not-admin user trying to perform admin-only operation.";
     }
 
     public static class Log {
+    	public static final String ADDING_NEW_PROVIDER = "Adding provider: %s";
+    	public static final String ADDING_REQUESTER_PROVIDER = "Adding requester: %s";
+    	public static final String ADDING_TARGET_PROVIDER = "Adding target: %s";
+    	public static final String GET_PUBLIC_KEY = "Get public key received.";
         public static final String INTERNAL_SERVER_ERROR = "Internal server error.";
-        public static final String GET_PUBLIC_KEY = "Get public key received.";
+        public static final String RELOADING_AUTHORIZATION_PLUGIN = "Reloading authorization plugin.";
+        public static final String RELOADING_CONFIGURATION = "Reloading service configuration.";
+        public static final Object RELOADING_MEMBERSHIP_PLUGIN = "Reloading membership plugin.";
+        public static final String RELOADING_MS_KEYS_HOLDER = "Reloading service keys.";
+        public static final String RELOADING_PROPERTIES_HOLDER = "Reloading properties holder.";
+        public static final String RELOADING_PUBLIC_KEYS_HOLDER = "Reloading public keys holder.";
+		public static final String REMOVING_PROVIDER = "Removing provider: %s";
+		public static final String REMOVING_REQUESTER_PROVIDER = "Removing requester: %s";
+		public static final String REMOVING_TARGET_PROVIDER = "Removing target: %s";
     }
 }

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -5,6 +5,8 @@ public class Messages {
         public static final String DEFAULT_ROLE_NAME_IS_INVALID = "Default role name is invalid.";
         public static final String GENERIC_EXCEPTION_S = "Operation returned error: %s.";
         public static final String INVALID_MEMBER_NAME = "Invalid member name in configuration.";
+        public static final String MEMBER_IS_NOT_REQUESTER = "Member is not requester.";
+        public static final String MEMBER_IS_NOT_TARGET = "Member is not target.";
         public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member";
         public static final String UNABLE_TO_FIND_CLASS_S = "Unable to find class %s.";
     }

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -5,6 +5,7 @@ public class Messages {
         public static final String DEFAULT_ROLE_NAME_IS_INVALID = "Default role name is invalid.";
         public static final String GENERIC_EXCEPTION_S = "Operation returned error: %s.";
         public static final String INVALID_MEMBER_NAME = "Invalid member name in configuration.";
+        public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member";
         public static final String UNABLE_TO_FIND_CLASS_S = "Unable to find class %s.";
     }
 

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -11,6 +11,7 @@ public class Messages {
         public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member.";
         public static final String PROVIDER_IS_ALREADY_A_REQUESTER = "Provider is already a requester.";
         public static final String PROVIDER_IS_ALREADY_A_TARGET = "Provider is already a target.";
+        public static final String PROVIDER_MUST_BE_TARGET_REQUESTER_OR_BOTH = "Provider must be target, requester, or both.";
         public static final String UNABLE_TO_FIND_CLASS_S = "Unable to find class %s.";
 		public static final String USER_IS_NOT_ADMIN = "Not-admin user trying to perform admin-only operation.";
     }

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -7,7 +7,9 @@ public class Messages {
         public static final String INVALID_MEMBER_NAME = "Invalid member name in configuration.";
         public static final String MEMBER_IS_NOT_REQUESTER = "Member is not requester.";
         public static final String MEMBER_IS_NOT_TARGET = "Member is not target.";
-        public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member";
+        public static final String PROVIDER_IS_ALREADY_A_MEMBER = "Provider is already a member.";
+        public static final String PROVIDER_IS_ALREADY_A_REQUESTER = "Provider is already a requester.";
+        public static final String PROVIDER_IS_ALREADY_A_TARGET = "Provider is already a target.";
         public static final String UNABLE_TO_FIND_CLASS_S = "Unable to find class %s.";
     }
 

--- a/src/main/java/cloud/fogbow/ms/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ms/constants/Messages.java
@@ -17,20 +17,20 @@ public class Messages {
     }
 
     public static class Log {
-    	public static final String ADDING_NEW_PROVIDER = "Adding provider: %s";
-    	public static final String ADDING_REQUESTER_PROVIDER = "Adding requester: %s";
-    	public static final String ADDING_TARGET_PROVIDER = "Adding target: %s";
-    	public static final String CHANGING_MEMBERSHIP_PLUGIN = "Changing membership plugin to: %s";
+    	public static final String ADDING_NEW_PROVIDER = "Adding provider: %s.";
+    	public static final String ADDING_REQUESTER_PROVIDER = "Adding requester: %s.";
+    	public static final String ADDING_TARGET_PROVIDER = "Adding target: %s.";
+    	public static final String CHANGING_MEMBERSHIP_PLUGIN = "Changing membership plugin to: %s.";
     	public static final String GET_PUBLIC_KEY = "Get public key received.";
         public static final String INTERNAL_SERVER_ERROR = "Internal server error.";
         public static final String RELOADING_AUTHORIZATION_PLUGIN = "Reloading authorization plugin.";
         public static final String RELOADING_CONFIGURATION = "Reloading service configuration.";
-        public static final Object RELOADING_MEMBERSHIP_PLUGIN = "Reloading membership plugin.";
+        public static final String RELOADING_MEMBERSHIP_PLUGIN = "Reloading membership plugin.";
         public static final String RELOADING_MS_KEYS_HOLDER = "Reloading service keys.";
         public static final String RELOADING_PROPERTIES_HOLDER = "Reloading properties holder.";
         public static final String RELOADING_PUBLIC_KEYS_HOLDER = "Reloading public keys holder.";
-		public static final String REMOVING_PROVIDER = "Removing provider: %s";
-		public static final String REMOVING_REQUESTER_PROVIDER = "Removing requester: %s";
-		public static final String REMOVING_TARGET_PROVIDER = "Removing target: %s";
+		public static final String REMOVING_PROVIDER = "Removing provider: %s.";
+		public static final String REMOVING_REQUESTER_PROVIDER = "Removing requester: %s.";
+		public static final String REMOVING_TARGET_PROVIDER = "Removing target: %s.";
     }
 }

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -15,6 +15,7 @@ import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.CryptoUtil;
 import cloud.fogbow.common.util.ServiceAsymmetricKeysHolder;
+import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.authorization.AdminOperation;
 
 // TODO add tests
@@ -89,11 +90,12 @@ public class ApplicationFacade {
     }
     
     public void addProvider(String userToken, String provider) throws FogbowException {
+    	LOGGER.info(String.format(Messages.Log.ADDING_NEW_PROVIDER, provider));
+
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
     	
-    	// TODO add logging
     	setAsReloading();
     	
     	try {
@@ -104,11 +106,12 @@ public class ApplicationFacade {
     }
     
 	public void removeProvider(String userToken, String provider) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, provider));
+		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
-		
-    	// TODO add logging
+    	
     	setAsReloading();
     	
     	try {
@@ -119,11 +122,12 @@ public class ApplicationFacade {
 	}
     
 	public void addTargetProvider(String userToken, String provider) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.ADDING_TARGET_PROVIDER, provider));
+		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
-		
-    	// TODO add logging
+    	
     	setAsReloading();
     	
     	try {
@@ -135,11 +139,12 @@ public class ApplicationFacade {
 	}
 
 	public void addRequesterProvider(String userToken, String provider) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.ADDING_REQUESTER_PROVIDER, provider));
+		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
-		
-    	// TODO add logging
+
     	setAsReloading();
     	
     	try {
@@ -151,11 +156,12 @@ public class ApplicationFacade {
 	}
     
 	public void removeTargetProvider(String userToken, String provider) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.REMOVING_TARGET_PROVIDER, provider));
+		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
     	
-    	// TODO add logging
     	setAsReloading();
     	
     	try {
@@ -166,11 +172,12 @@ public class ApplicationFacade {
 	}
 
 	public void removeRequesterProvider(String userToken, String provider) throws FogbowException {
-    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+		LOGGER.info(String.format(Messages.Log.REMOVING_REQUESTER_PROVIDER, provider));
+		
+		RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
     	
-    	// TODO add logging
     	setAsReloading();
     	
     	try {
@@ -182,6 +189,8 @@ public class ApplicationFacade {
 	}
 	
     public void reload(String userToken) throws FogbowException {
+    	LOGGER.info(Messages.Log.RELOADING_CONFIGURATION);
+    	
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
@@ -201,17 +210,21 @@ public class ApplicationFacade {
 	            }
 	        }
 			
-	        // TODO add logging
+	        LOGGER.info(Messages.Log.RELOADING_PROPERTIES_HOLDER);
 			PropertiesHolder.reset();
+			
+			LOGGER.info(Messages.Log.RELOADING_PUBLIC_KEYS_HOLDER);
 	        MSPublicKeysHolder.reset();
 	        
-	        // TODO add logging
+	        LOGGER.info(Messages.Log.RELOADING_MS_KEYS_HOLDER);
 	        String publicKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PUBLIC_KEY_FILE_PATH);
 	        String privateKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PRIVATE_KEY_FILE_PATH);
 	        ServiceAsymmetricKeysHolder.reset(publicKeyFilePath, privateKeyFilePath);
 			
-	        // TODO add logging
+	        LOGGER.info(Messages.Log.RELOADING_AUTHORIZATION_PLUGIN);
 			this.authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
+			
+			LOGGER.info(Messages.Log.RELOADING_MEMBERSHIP_PLUGIN);
 			this.membershipService = PluginInstantiator.getMembershipService();
 		} finally {
 			finishReloading();

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -93,21 +93,21 @@ public class ApplicationFacade {
     public void setAuthorizationPlugin(AuthorizationPlugin<MsOperation> authorizationPlugin) {
     	this.authorizationPlugin = authorizationPlugin;
     }
-    
-    public void addProvider(String userToken, String provider) throws FogbowException {
-    	LOGGER.info(String.format(Messages.Log.ADDING_NEW_PROVIDER, provider));
 
-    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
-    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
-    	
-    	setAsReloading();
-    	
-    	try {
-    		this.membershipService.addMember(provider);
-    	} finally {
-    		finishReloading();    		
-    	}
+    public void addProvider(String userToken, String provider, boolean target, boolean requester) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, provider));
+        
+        RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+        SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+        this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
+        
+        setAsReloading();        
+        
+        try {
+            this.membershipService.addMember(provider, target, requester);
+        } finally {
+            finishReloading();
+        }
     }
     
 	public void removeProvider(String userToken, String provider) throws FogbowException {
@@ -125,74 +125,23 @@ public class ApplicationFacade {
     		finishReloading();    		
     	}
 	}
-    
-	public void addTargetProvider(String userToken, String provider) throws FogbowException {
-		LOGGER.info(String.format(Messages.Log.ADDING_TARGET_PROVIDER, provider));
-		
-    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
-    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
-    	
-    	setAsReloading();
-    	
-    	try {
-    		this.membershipService.addTarget(provider);
-    	} finally {
-    		finishReloading();    		
-    	}
-    	
-	}
-
-	public void addRequesterProvider(String userToken, String provider) throws FogbowException {
-		LOGGER.info(String.format(Messages.Log.ADDING_REQUESTER_PROVIDER, provider));
-		
-    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
-    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
-
-    	setAsReloading();
-    	
-    	try {
-    		this.membershipService.addRequester(provider);
-    	} finally {
-    		finishReloading();    		
-    	}
-		
-	}
-    
-	public void removeTargetProvider(String userToken, String provider) throws FogbowException {
-		LOGGER.info(String.format(Messages.Log.REMOVING_TARGET_PROVIDER, provider));
-		
-    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
-    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
-    	
-    	setAsReloading();
-    	
-    	try {
-    		this.membershipService.removeTarget(provider);
-    	} finally {
-    		finishReloading();    		
-    	}
-	}
-
-	public void removeRequesterProvider(String userToken, String provider) throws FogbowException {
-		LOGGER.info(String.format(Messages.Log.REMOVING_REQUESTER_PROVIDER, provider));
-		
-		RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
-    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
-    	
-    	setAsReloading();
-    	
-    	try {
-    		this.membershipService.removeRequester(provider);
-    	} finally {
-    		finishReloading();    		
-    	}
-		
-	}
 	
+    public void updateProvider(String userToken, String provider, boolean target, boolean requester) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, provider));
+        
+        RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+        SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+        this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
+        
+        setAsReloading();
+        
+        try {
+            this.membershipService.updateMember(provider, target, requester);
+        } finally {
+            finishReloading();
+        }
+    }
+    
     public void reload(String userToken) throws FogbowException {
     	LOGGER.info(Messages.Log.RELOADING_CONFIGURATION);
     	

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -88,6 +88,16 @@ public class ApplicationFacade {
     	this.authorizationPlugin = authorizationPlugin;
     }
     
+    public void addProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	
+    	setAsReloading();
+    	this.membershipService.addMember(provider);
+    	finishReloading();
+    }
+    
     public void reload(String userToken) throws FogbowException {
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -15,6 +15,7 @@ import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.CryptoUtil;
 import cloud.fogbow.common.util.ServiceAsymmetricKeysHolder;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.authorization.MsOperation;
@@ -94,8 +95,8 @@ public class ApplicationFacade {
     	this.authorizationPlugin = authorizationPlugin;
     }
 
-    public void addProvider(String userToken, String provider, boolean target, boolean requester) throws FogbowException {
-        LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, provider));
+    public void addProvider(String userToken, ProviderPermission permission) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, permission.getProvider()));
         
         RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
         SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
@@ -104,7 +105,7 @@ public class ApplicationFacade {
         setAsReloading();        
         
         try {
-            this.membershipService.addMember(provider, target, requester);
+            this.membershipService.addMember(permission);
         } finally {
             finishReloading();
         }
@@ -126,7 +127,7 @@ public class ApplicationFacade {
     	}
 	}
 	
-    public void updateProvider(String userToken, String provider, boolean target, boolean requester) throws FogbowException {
+    public void updateProvider(String userToken, ProviderPermission provider) throws FogbowException {
         LOGGER.info(String.format(Messages.Log.REMOVING_PROVIDER, provider));
         
         RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
@@ -136,7 +137,7 @@ public class ApplicationFacade {
         setAsReloading();
         
         try {
-            this.membershipService.updateMember(provider, target, requester);
+            this.membershipService.updateMember(provider);
         } finally {
             finishReloading();
         }

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -103,6 +103,21 @@ public class ApplicationFacade {
     	}
     }
     
+	public void removeProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+		
+    	// TODO add logging
+    	setAsReloading();
+    	
+    	try {
+    		this.membershipService.removeMember(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
+	}
+    
 	public void addTargetProvider(String userToken, String provider) throws FogbowException {
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -1,20 +1,32 @@
 package cloud.fogbow.ms.core;
 
 import java.security.GeneralSecurityException;
+import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import cloud.fogbow.as.core.util.AuthenticationUtil;
+import cloud.fogbow.common.constants.FogbowConstants;
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InternalServerErrorException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.CryptoUtil;
 import cloud.fogbow.common.util.ServiceAsymmetricKeysHolder;
+import cloud.fogbow.ms.core.authorization.AdminOperation;
 
+// TODO add tests
 public class ApplicationFacade {
 
     private static final Logger LOGGER = Logger.getLogger(ApplicationFacade.class);
 
     private static ApplicationFacade instance;
     private MembershipService membershipService;
+    private AuthorizationPlugin<AdminOperation> authorizationPlugin;
+	private long onGoingRequests;
+	private boolean reloading;
     
     public static ApplicationFacade getInstance() {
         if (instance == null) {
@@ -24,32 +36,110 @@ public class ApplicationFacade {
     }
 
     private ApplicationFacade() {
-
+        this.onGoingRequests = 0;
+        this.reloading = false;
     }
     
     public List<String> listMembers() throws Exception {
-        return this.membershipService.listMembers();
+    	startOperation();
+    	try {
+    		return this.membershipService.listMembers();    		
+    	} finally {
+    		finishOperation();
+    	}
     }
 
     public String getPublicKey() throws InternalServerErrorException {
+    	startOperation();
         try {
             return CryptoUtil.toBase64(ServiceAsymmetricKeysHolder.getInstance().getPublicKey());
         } catch (GeneralSecurityException e) {
             throw new InternalServerErrorException(e.getMessage());
         } catch (InternalServerErrorException e) {
             throw new InternalServerErrorException(e.getMessage());
-        } 
+        } finally {
+        	finishOperation();
+        }
     }
 
     public boolean isTargetAuthorized(String provider) {
-        return this.membershipService.isTargetAuthorized(provider);
+    	startOperation();
+    	try {
+    		return this.membershipService.isTargetAuthorized(provider);    		
+    	} finally {
+    		finishOperation();
+    	}
     }
 
     public boolean isRequesterAuthorized(String provider) {
-        return this.membershipService.isRequesterAuthorized(provider);
+    	startOperation();
+    	try {
+    		return this.membershipService.isRequesterAuthorized(provider);    		
+    	} finally {
+    		finishOperation();
+    	}
     }
 
     public void setMembershipService(MembershipService membershipService) {
         this.membershipService = membershipService;
+    }
+    
+    public void setAuthorizationPlugin(AuthorizationPlugin<AdminOperation> authorizationPlugin) {
+    	this.authorizationPlugin = authorizationPlugin;
+    }
+    
+    public void reload(String userToken) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	
+    	doReload();
+    }
+
+	private void doReload() throws ConfigurationErrorException {
+		setAsReloading();
+		
+        while (this.onGoingRequests != 0) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+		
+        // TODO add logging
+		PropertiesHolder.reset();
+        MSPublicKeysHolder.reset();
+        
+        // TODO add logging
+        String publicKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PUBLIC_KEY_FILE_PATH);
+        String privateKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PRIVATE_KEY_FILE_PATH);
+        ServiceAsymmetricKeysHolder.reset(publicKeyFilePath, privateKeyFilePath);
+		
+        // TODO add logging
+		this.authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
+		this.membershipService = PluginInstantiator.getMembershipService();
+		
+		finishReloading();
+	}
+	
+    private void setAsReloading() {
+        this.reloading = true;
+    }
+    
+    private void finishReloading() {
+    	this.reloading = false;
+    }
+	
+    private void startOperation() {
+        while (reloading)
+            ;
+        synchronized (this) {
+            this.onGoingRequests++;
+        }
+    }
+    
+    private synchronized void finishOperation() {
+        this.onGoingRequests--;
     }
 }

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -20,7 +20,6 @@ import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.authorization.MsOperation;
 
-// TODO add tests
 public class ApplicationFacade {
 
     private static final Logger LOGGER = Logger.getLogger(ApplicationFacade.class);

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -135,6 +135,37 @@ public class ApplicationFacade {
 		
 	}
     
+	public void removeTargetProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	
+    	// TODO add logging
+    	setAsReloading();
+    	
+    	try {
+    		this.membershipService.removeTarget(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
+	}
+
+	public void removeRequesterProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	
+    	// TODO add logging
+    	setAsReloading();
+    	
+    	try {
+    		this.membershipService.removeRequester(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
+		
+	}
+	
     public void reload(String userToken) throws FogbowException {
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
@@ -191,5 +222,4 @@ public class ApplicationFacade {
     private synchronized void finishOperation() {
         this.onGoingRequests--;
     }
-
 }

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -93,10 +93,47 @@ public class ApplicationFacade {
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
     	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
     	
+    	// TODO add logging
     	setAsReloading();
-    	this.membershipService.addMember(provider);
-    	finishReloading();
+    	
+    	try {
+    		this.membershipService.addMember(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
     }
+    
+	public void addTargetProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+		
+    	// TODO add logging
+    	setAsReloading();
+    	
+    	try {
+    		this.membershipService.addTarget(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
+    	
+	}
+
+	public void addRequesterProvider(String userToken, String provider) throws FogbowException {
+    	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
+    	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
+    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+		
+    	// TODO add logging
+    	setAsReloading();
+    	
+    	try {
+    		this.membershipService.addRequester(provider);
+    	} finally {
+    		finishReloading();    		
+    	}
+		
+	}
     
     public void reload(String userToken) throws FogbowException {
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
@@ -152,4 +189,5 @@ public class ApplicationFacade {
     private synchronized void finishOperation() {
         this.onGoingRequests--;
     }
+
 }

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -17,7 +17,7 @@ import cloud.fogbow.common.util.CryptoUtil;
 import cloud.fogbow.common.util.ServiceAsymmetricKeysHolder;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.constants.Messages;
-import cloud.fogbow.ms.core.authorization.AdminOperation;
+import cloud.fogbow.ms.core.authorization.MsOperation;
 
 // TODO add tests
 public class ApplicationFacade {
@@ -26,7 +26,7 @@ public class ApplicationFacade {
 
     private static ApplicationFacade instance;
     private MembershipService membershipService;
-    private AuthorizationPlugin<AdminOperation> authorizationPlugin;
+    private AuthorizationPlugin<MsOperation> authorizationPlugin;
 	private long onGoingRequests;
 	private boolean reloading;
     
@@ -90,7 +90,7 @@ public class ApplicationFacade {
         return membershipService;
     }
     
-    public void setAuthorizationPlugin(AuthorizationPlugin<AdminOperation> authorizationPlugin) {
+    public void setAuthorizationPlugin(AuthorizationPlugin<MsOperation> authorizationPlugin) {
     	this.authorizationPlugin = authorizationPlugin;
     }
     
@@ -99,7 +99,7 @@ public class ApplicationFacade {
 
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	setAsReloading();
     	
@@ -115,7 +115,7 @@ public class ApplicationFacade {
 		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	setAsReloading();
     	
@@ -131,7 +131,7 @@ public class ApplicationFacade {
 		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	setAsReloading();
     	
@@ -148,7 +148,7 @@ public class ApplicationFacade {
 		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
 
     	setAsReloading();
     	
@@ -165,7 +165,7 @@ public class ApplicationFacade {
 		
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	setAsReloading();
     	
@@ -181,7 +181,7 @@ public class ApplicationFacade {
 		
 		RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	setAsReloading();
     	
@@ -198,7 +198,7 @@ public class ApplicationFacade {
     	
     	RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
     	SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-    	this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+    	this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
     	
     	doReload();
     }
@@ -239,7 +239,7 @@ public class ApplicationFacade {
     public void updateMembershipService(String userToken, String className) throws FogbowException {
         RSAPublicKey asPublicKey = MSPublicKeysHolder.getInstance().getAsPublicKey();
         SystemUser systemUser = AuthenticationUtil.authenticate(asPublicKey, userToken);
-        this.authorizationPlugin.isAuthorized(systemUser, new AdminOperation());
+        this.authorizationPlugin.isAuthorized(systemUser, new MsOperation());
         
         setAsReloading();
         

--- a/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ms/core/ApplicationFacade.java
@@ -146,28 +146,30 @@ public class ApplicationFacade {
 	private void doReload() throws ConfigurationErrorException {
 		setAsReloading();
 		
-        while (this.onGoingRequests != 0) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
-		
-        // TODO add logging
-		PropertiesHolder.reset();
-        MSPublicKeysHolder.reset();
-        
-        // TODO add logging
-        String publicKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PUBLIC_KEY_FILE_PATH);
-        String privateKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PRIVATE_KEY_FILE_PATH);
-        ServiceAsymmetricKeysHolder.reset(publicKeyFilePath, privateKeyFilePath);
-		
-        // TODO add logging
-		this.authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
-		this.membershipService = PluginInstantiator.getMembershipService();
-		
-		finishReloading();
+		try {
+	        while (this.onGoingRequests != 0) {
+	            try {
+	                Thread.sleep(10);
+	            } catch (InterruptedException e) {
+	                e.printStackTrace();
+	            }
+	        }
+			
+	        // TODO add logging
+			PropertiesHolder.reset();
+	        MSPublicKeysHolder.reset();
+	        
+	        // TODO add logging
+	        String publicKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PUBLIC_KEY_FILE_PATH);
+	        String privateKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PRIVATE_KEY_FILE_PATH);
+	        ServiceAsymmetricKeysHolder.reset(publicKeyFilePath, privateKeyFilePath);
+			
+	        // TODO add logging
+			this.authorizationPlugin = PluginInstantiator.getAuthorizationPlugin();
+			this.membershipService = PluginInstantiator.getMembershipService();
+		} finally {
+			finishReloading();
+		}
 	}
 	
     private void setAsReloading() {

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -2,6 +2,8 @@ package cloud.fogbow.ms.core;
 
 import java.util.List;
 
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+
 public interface MembershipService {
 
     /**
@@ -27,4 +29,8 @@ public interface MembershipService {
     public boolean isRequesterAuthorized(String provider);
 
 	public void addMember(String provider);
+
+	public void addTarget(String provider) throws ConfigurationErrorException;
+
+	public void addRequester(String provider) throws ConfigurationErrorException;
 }

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -25,4 +25,6 @@ public interface MembershipService {
     public boolean isTargetAuthorized(String provider);
 
     public boolean isRequesterAuthorized(String provider);
+
+	public void addMember(String provider);
 }

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -19,24 +19,58 @@ public interface MembershipService {
      * Returns whether or not the given provider is in 
      * the list of known providers.
      * 
-     * @param provider
+     * @param provider - the name of the provider to check membership.
      * @return a boolean value stating whether the given 
      * provider is a member or not.
      */
     public boolean isMember(String provider);
 
-    // TODO documentation
+    /**
+     * Returns whether or not the local provider is allowed 
+     * to perform operations in the given provider
+     * 
+     * @param provider - the name of the provider to authorize.
+     * @return a boolean value stating whether or not the operation
+     * is authorized.
+     */
     public boolean isTargetAuthorized(String provider);
 
-    // TODO documentation
+    /**
+     * Returns whether or not the given provider is allowed
+     * to perform operations in the local provider.
+     * 
+     * @param provider - the name of the provider to authorize.
+     * @return a boolean value stating whether or not the operation
+     * is authorized.
+     */
     public boolean isRequesterAuthorized(String provider);
 
-    // TODO documentation
+    /**
+     * Adds given provider to the list of members, using the
+     * given permission information.
+     * 
+     * @param permission - the permissions to use when authorizing
+     * operations related to the new provider.
+     * @throws ConfigurationErrorException - If the given provider
+     * is already in the members list or the permissions are invalid.
+     */
     public void addMember(ProviderPermission permission) throws ConfigurationErrorException;
     
-    // TODO documentation
+    /**
+     * Updates permissions for the given provider.
+     * 
+     * @param provider - the new permissions to use.
+     * @throws ConfigurationErrorException - If the given provider is
+     * not a member or the permissions are invalid.
+     */
     public void updateMember(ProviderPermission provider) throws ConfigurationErrorException;
    
-    // TODO documentation
+    /**
+     * Removes given provider from all the list of members.
+     * 
+     * @param provider - the name of the provider to remove.
+     * @throws ConfigurationErrorException - If the given provider
+     * is not a member.
+     */
 	public void removeMember(String provider) throws ConfigurationErrorException;
 }

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -33,4 +33,8 @@ public interface MembershipService {
 	public void addTarget(String provider) throws ConfigurationErrorException;
 
 	public void addRequester(String provider) throws ConfigurationErrorException;
+
+	public void removeTarget(String provider) throws ConfigurationErrorException;
+
+	public void removeRequester(String provider) throws ConfigurationErrorException;
 }

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -28,7 +28,7 @@ public interface MembershipService {
 
     public boolean isRequesterAuthorized(String provider);
 
-	public void addMember(String provider);
+	public void addMember(String provider) throws ConfigurationErrorException;
 
 	public void addTarget(String provider) throws ConfigurationErrorException;
 

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ms.core;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 
 public interface MembershipService {
 
@@ -31,10 +32,10 @@ public interface MembershipService {
     public boolean isRequesterAuthorized(String provider);
 
     // TODO documentation
-    public void addMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException;
+    public void addMember(ProviderPermission permission) throws ConfigurationErrorException;
     
     // TODO documentation
-    public void updateMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException;
+    public void updateMember(ProviderPermission provider) throws ConfigurationErrorException;
    
     // TODO documentation
 	public void removeMember(String provider) throws ConfigurationErrorException;

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -37,4 +37,6 @@ public interface MembershipService {
 	public void removeTarget(String provider) throws ConfigurationErrorException;
 
 	public void removeRequester(String provider) throws ConfigurationErrorException;
+
+	public void removeMember(String provider) throws ConfigurationErrorException;
 }

--- a/src/main/java/cloud/fogbow/ms/core/MembershipService.java
+++ b/src/main/java/cloud/fogbow/ms/core/MembershipService.java
@@ -24,19 +24,18 @@ public interface MembershipService {
      */
     public boolean isMember(String provider);
 
+    // TODO documentation
     public boolean isTargetAuthorized(String provider);
 
+    // TODO documentation
     public boolean isRequesterAuthorized(String provider);
 
-	public void addMember(String provider) throws ConfigurationErrorException;
-
-	public void addTarget(String provider) throws ConfigurationErrorException;
-
-	public void addRequester(String provider) throws ConfigurationErrorException;
-
-	public void removeTarget(String provider) throws ConfigurationErrorException;
-
-	public void removeRequester(String provider) throws ConfigurationErrorException;
-
+    // TODO documentation
+    public void addMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException;
+    
+    // TODO documentation
+    public void updateMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException;
+   
+    // TODO documentation
 	public void removeMember(String provider) throws ConfigurationErrorException;
 }

--- a/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
@@ -4,7 +4,7 @@ import cloud.fogbow.common.exceptions.ConfigurationErrorException;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.authorization.AdminAuthorizationPlugin;
-import cloud.fogbow.ms.core.authorization.AdminOperation;
+import cloud.fogbow.ms.core.authorization.MsOperation;
 import cloud.fogbow.ms.core.service.AllowList;
 
 public class PluginInstantiator {
@@ -19,7 +19,7 @@ public class PluginInstantiator {
         }
     }
 
-	public static AuthorizationPlugin<AdminOperation> getAuthorizationPlugin() throws ConfigurationErrorException {
+	public static AuthorizationPlugin<MsOperation> getAuthorizationPlugin() throws ConfigurationErrorException {
         if (PropertiesHolder.getInstance().getProperties().containsKey(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY)) {
             String className = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY);
             return getAuthorizationPlugin(className);
@@ -28,8 +28,8 @@ public class PluginInstantiator {
         }
 	}
 	
-	public static AuthorizationPlugin<AdminOperation> getAuthorizationPlugin(String className) {
-        return (AuthorizationPlugin<AdminOperation>) PluginInstantiator.classFactory.createPluginInstance(className);
+	public static AuthorizationPlugin<MsOperation> getAuthorizationPlugin(String className) {
+        return (AuthorizationPlugin<MsOperation>) PluginInstantiator.classFactory.createPluginInstance(className);
 	}
 	
 	public static MembershipService getMembershipService(String className) {

--- a/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
@@ -1,7 +1,10 @@
 package cloud.fogbow.ms.core;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ms.core.authorization.AdminAuthorizationPlugin;
+import cloud.fogbow.ms.core.authorization.AdminOperation;
 import cloud.fogbow.ms.core.service.AllowList;
 
 public class PluginInstantiator {
@@ -15,5 +18,14 @@ public class PluginInstantiator {
             return new AllowList();
         }
     }
+
+	public static AuthorizationPlugin<AdminOperation> getAuthorizationPlugin() throws ConfigurationErrorException {
+        if (PropertiesHolder.getInstance().getProperties().containsKey(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY)) {
+            String className = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY);
+            return (AuthorizationPlugin<AdminOperation>) PluginInstantiator.classFactory.createPluginInstance(className);
+        } else {
+            return new AdminAuthorizationPlugin();
+        }
+	}
         
 }

--- a/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ms/core/PluginInstantiator.java
@@ -13,7 +13,7 @@ public class PluginInstantiator {
     public static MembershipService getMembershipService() throws ConfigurationErrorException {
         if (PropertiesHolder.getInstance().getProperties().containsKey(ConfigurationPropertyKeys.MEMBERSHIP_SERVICE_CLASS_KEY)) {
             String className = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.MEMBERSHIP_SERVICE_CLASS_KEY);
-            return (MembershipService) PluginInstantiator.classFactory.createPluginInstance(className);
+            return getMembershipService(className);
         } else {
             return new AllowList();
         }
@@ -22,10 +22,18 @@ public class PluginInstantiator {
 	public static AuthorizationPlugin<AdminOperation> getAuthorizationPlugin() throws ConfigurationErrorException {
         if (PropertiesHolder.getInstance().getProperties().containsKey(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY)) {
             String className = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.AUTHORIZATION_PLUGIN_CLASS_KEY);
-            return (AuthorizationPlugin<AdminOperation>) PluginInstantiator.classFactory.createPluginInstance(className);
+            return getAuthorizationPlugin(className);
         } else {
             return new AdminAuthorizationPlugin();
         }
+	}
+	
+	public static AuthorizationPlugin<AdminOperation> getAuthorizationPlugin(String className) {
+        return (AuthorizationPlugin<AdminOperation>) PluginInstantiator.classFactory.createPluginInstance(className);
+	}
+	
+	public static MembershipService getMembershipService(String className) {
+	    return (MembershipService) PluginInstantiator.classFactory.createPluginInstance(className);
 	}
         
 }

--- a/src/main/java/cloud/fogbow/ms/core/PropertiesHolder.java
+++ b/src/main/java/cloud/fogbow/ms/core/PropertiesHolder.java
@@ -39,4 +39,8 @@ public class PropertiesHolder {
     public Properties getProperties() {
         return this.properties;
     }
+    
+    public static synchronized void reset() {
+        instance = null;
+    }
 }

--- a/src/main/java/cloud/fogbow/ms/core/PropertiesHolder.java
+++ b/src/main/java/cloud/fogbow/ms/core/PropertiesHolder.java
@@ -27,6 +27,10 @@ public class PropertiesHolder {
     public String getProperty(String propertyName) {
         return properties.getProperty(propertyName);
     }
+    
+    public void setProperty(String propertyName, String propertyValue) {
+    	properties.setProperty(propertyName, propertyValue);
+    }
 
     public String getProperty(String propertyName, String defaultPropertyValue) {
         String propertyValue = this.properties.getProperty(propertyName, defaultPropertyValue);
@@ -42,5 +46,11 @@ public class PropertiesHolder {
     
     public static synchronized void reset() {
         instance = null;
+    }
+    
+    public void updatePropertiesFile() {
+        String path = HomeDir.getPath();
+        String configFileName = path + SystemConstants.CONF_FILE_NAME;
+    	PropertiesUtil.writeProperties(properties, configFileName);
     }
 }

--- a/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
@@ -1,0 +1,45 @@
+package cloud.fogbow.ms.core.authorization;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
+import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ms.core.PropertiesHolder;
+
+public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperation> {
+
+	private Set<String> adminsIds;
+	
+	public AdminAuthorizationPlugin() throws ConfigurationErrorException {
+		adminsIds = new HashSet<String>();
+		String adminsIdsString = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.ADMINS_IDS);
+		
+		if (adminsIdsString.isEmpty()) {
+			// TODO add message
+			throw new ConfigurationErrorException();
+		}
+		
+		// TODO constant
+		for (String adminId : adminsIdsString.split(",")) {
+			adminsIds.add(adminId);
+		}
+	}
+	
+	
+	@Override
+	public boolean isAuthorized(SystemUser systemUser, AdminOperation operation) throws UnauthorizedRequestException {
+		String userId = systemUser.getId();
+		
+		if (!adminsIds.contains(userId)) {
+			// TODO add message
+			throw new UnauthorizedRequestException();
+		}
+		
+		return true;
+	}
+
+}

--- a/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
@@ -11,7 +11,7 @@ import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.PropertiesHolder;
 
-public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperation> {
+public class AdminAuthorizationPlugin implements AuthorizationPlugin<MsOperation> {
 
 	private static final String SEPARATOR = ",";
 	private Set<String> adminsIds;
@@ -31,7 +31,7 @@ public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperat
 	
 	
 	@Override
-	public boolean isAuthorized(SystemUser systemUser, AdminOperation operation) throws UnauthorizedRequestException {
+	public boolean isAuthorized(SystemUser systemUser, MsOperation operation) throws UnauthorizedRequestException {
 		String userId = systemUser.getId();
 		
 		if (!adminsIds.contains(userId)) {

--- a/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPlugin.java
@@ -8,10 +8,12 @@ import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.PropertiesHolder;
 
 public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperation> {
 
+	private static final String SEPARATOR = ",";
 	private Set<String> adminsIds;
 	
 	public AdminAuthorizationPlugin() throws ConfigurationErrorException {
@@ -19,12 +21,10 @@ public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperat
 		String adminsIdsString = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.ADMINS_IDS);
 		
 		if (adminsIdsString.isEmpty()) {
-			// TODO add message
-			throw new ConfigurationErrorException();
+			throw new ConfigurationErrorException(Messages.Exception.NO_ADMIN_SPECIFIED);
 		}
 		
-		// TODO constant
-		for (String adminId : adminsIdsString.split(",")) {
+		for (String adminId : adminsIdsString.split(SEPARATOR)) {
 			adminsIds.add(adminId);
 		}
 	}
@@ -35,8 +35,7 @@ public class AdminAuthorizationPlugin implements AuthorizationPlugin<AdminOperat
 		String userId = systemUser.getId();
 		
 		if (!adminsIds.contains(userId)) {
-			// TODO add message
-			throw new UnauthorizedRequestException();
+			throw new UnauthorizedRequestException(Messages.Exception.USER_IS_NOT_ADMIN);
 		}
 		
 		return true;

--- a/src/main/java/cloud/fogbow/ms/core/authorization/AdminOperation.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/AdminOperation.java
@@ -4,4 +4,8 @@ import cloud.fogbow.common.models.FogbowOperation;
 
 public class AdminOperation extends FogbowOperation {
 
+	@Override
+	public boolean equals(Object o) {
+		return true;
+	}
 }

--- a/src/main/java/cloud/fogbow/ms/core/authorization/AdminOperation.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/AdminOperation.java
@@ -1,0 +1,7 @@
+package cloud.fogbow.ms.core.authorization;
+
+import cloud.fogbow.common.models.FogbowOperation;
+
+public class AdminOperation extends FogbowOperation {
+
+}

--- a/src/main/java/cloud/fogbow/ms/core/authorization/MsOperation.java
+++ b/src/main/java/cloud/fogbow/ms/core/authorization/MsOperation.java
@@ -2,7 +2,7 @@ package cloud.fogbow.ms.core.authorization;
 
 import cloud.fogbow.common.models.FogbowOperation;
 
-public class AdminOperation extends FogbowOperation {
+public class MsOperation extends FogbowOperation {
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
@@ -11,6 +11,8 @@ public class AllowList extends MembershipListService implements MembershipServic
         this.membersList = readMembers();
         this.targetMembers = readTargetMembers();
         this.requesterMembers = readRequesterMembers();
+        
+        validateMembersList();
     }
 
     /**

--- a/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
@@ -3,15 +3,14 @@ package cloud.fogbow.ms.core.service;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
-import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.MembershipService;
 
 public class AllowList extends MembershipListService implements MembershipService  {
     
     public AllowList() throws ConfigurationErrorException {
         this.membersList = readMembers();
-        this.targetMembers = readTargetMembers(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        this.requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+        this.targetMembers = readTargetMembers();
+        this.requesterMembers = readRequesterMembers();
     }
 
     /**
@@ -36,14 +35,4 @@ public class AllowList extends MembershipListService implements MembershipServic
     public boolean isRequesterAuthorized(String provider) {
         return this.requesterMembers.contains(provider);
     }
-
-	@Override
-	public void addTarget(String provider) throws ConfigurationErrorException {
-		addTargetMember(provider, ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-	}
-
-	@Override
-	public void addRequester(String provider) throws ConfigurationErrorException {
-		addRequesterMember(provider, ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-	}
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
@@ -10,8 +10,8 @@ public class AllowList extends MembershipListService implements MembershipServic
     
     public AllowList() throws ConfigurationErrorException {
         this.membersList = readMembers();
-        this.targetMembers = readTargetMembers(ConfigurationPropertyKeys.AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
-        this.requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
+        this.targetMembers = readTargetMembers(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+        this.requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
     }
 
     /**
@@ -36,4 +36,14 @@ public class AllowList extends MembershipListService implements MembershipServic
     public boolean isRequesterAuthorized(String provider) {
         return this.requesterMembers.contains(provider);
     }
+
+	@Override
+	public void addTarget(String provider) throws ConfigurationErrorException {
+		addTargetMember(provider, ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+	}
+
+	@Override
+	public void addRequester(String provider) throws ConfigurationErrorException {
+		addRequesterMember(provider, ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+	}
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/AllowList.java
@@ -1,26 +1,17 @@
 package cloud.fogbow.ms.core.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
-import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.MembershipService;
-import cloud.fogbow.ms.core.PropertiesHolder;
 
-public class AllowList implements MembershipService {
-
-    private static final String SEPARATOR = ",";
-
-    private List<String> membersList;
-    private List<String> authorizedTargetMembers;
-    private List<String> authorizedRequesterMembers;
+public class AllowList extends MembershipListService implements MembershipService  {
     
     public AllowList() throws ConfigurationErrorException {
         this.membersList = readMembers();
-        this.authorizedTargetMembers = readAuthorizedTargetMembers();
-        this.authorizedRequesterMembers = readAuthorizedRequesterMembers();
+        this.targetMembers = readTargetMembers(ConfigurationPropertyKeys.AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
+        this.requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
     }
 
     /**
@@ -31,58 +22,6 @@ public class AllowList implements MembershipService {
         return this.membersList;
     }
 
-    private List<String> readMembers() {
-        List<String> membersList = new ArrayList<>();
-
-        String membersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        for (String member : membersListStr.split(SEPARATOR)) {
-            member = member.trim();
-            membersList.add(member);
-        }
-
-        return membersList;
-    }
-    
-    private List<String> readAuthorizedTargetMembers() throws ConfigurationErrorException {
-        List<String> authorizedTargetMembers = new ArrayList<String>();
-        
-        String authorizedTargetMembersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
-        
-        if (!authorizedTargetMembersListStr.isEmpty()) {
-            for (String member : authorizedTargetMembersListStr.split(SEPARATOR)) {
-                member = member.trim();
-                
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
-                
-                authorizedTargetMembers.add(member);
-            }
-        }
-        
-        return authorizedTargetMembers;
-    }
-    
-    private List<String> readAuthorizedRequesterMembers() throws ConfigurationErrorException {
-        List<String> authorizedRequesterMembers = new ArrayList<String>();
-        
-        String authorizedRequesterMembersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
-        
-        if (!authorizedRequesterMembersListStr.isEmpty()) {
-            for (String member : authorizedRequesterMembersListStr.split(SEPARATOR)) {
-                member = member.trim();
-                
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
-                
-                authorizedRequesterMembers.add(member);
-            }
-        }
-        
-        return authorizedRequesterMembers;
-    }
-
     @Override
     public boolean isMember(String provider) {
         return this.membersList.contains(provider);
@@ -90,11 +29,11 @@ public class AllowList implements MembershipService {
 
     @Override
     public boolean isTargetAuthorized(String provider) {
-        return this.authorizedTargetMembers.contains(provider);
+        return this.targetMembers.contains(provider);
     }
 
     @Override
     public boolean isRequesterAuthorized(String provider) {
-        return this.authorizedRequesterMembers.contains(provider);
+        return this.requesterMembers.contains(provider);
     }
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
@@ -1,26 +1,17 @@
 package cloud.fogbow.ms.core.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
-import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.MembershipService;
-import cloud.fogbow.ms.core.PropertiesHolder;
 
-public class BlockList implements MembershipService {
-
-    private static final String SEPARATOR = ",";
-
-    private List<String> membersList;
-    private List<String> notAuthorizedTargetMembers;
-    private List<String> notAuthorizedRequesterMembers;
+public class BlockList extends MembershipListService implements MembershipService {
     
     public BlockList() throws ConfigurationErrorException {
-        this.membersList = readMembers();
-        this.notAuthorizedTargetMembers = readNotAuthorizedTargetMembers();
-        this.notAuthorizedRequesterMembers = readNotAuthorizedRequesterMembers();
+        membersList = readMembers();
+        targetMembers = readTargetMembers(ConfigurationPropertyKeys.NOT_AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
+        requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.NOT_AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
     }
 
     /**
@@ -31,57 +22,6 @@ public class BlockList implements MembershipService {
         return this.membersList;
     }
 
-    private List<String> readMembers() {
-        List<String> membersList = new ArrayList<>();
-
-        String membersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        for (String member : membersListStr.split(SEPARATOR)) {
-            member = member.trim();
-            membersList.add(member);
-        }
-
-        return membersList;
-    }
-    
-    private List<String> readNotAuthorizedTargetMembers() throws ConfigurationErrorException {
-        List<String> notAuthorizedTargetMembers = new ArrayList<String>();
-        
-        String notAuthorizedTargetMembersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.NOT_AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
-        if (!notAuthorizedTargetMembersListStr.isEmpty()) {
-            for (String member : notAuthorizedTargetMembersListStr.split(SEPARATOR)) {
-                member = member.trim();
-                
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
-                
-                notAuthorizedTargetMembers.add(member);
-            }
-        }
-
-        return notAuthorizedTargetMembers;
-    }
-    
-    private List<String> readNotAuthorizedRequesterMembers() throws ConfigurationErrorException {
-        List<String> notAuthorizedTargetMembers = new ArrayList<String>();
-        
-        String notAuthorizedRequesterMembersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.NOT_AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
-        
-        if (!notAuthorizedRequesterMembersListStr.isEmpty()) {
-            for (String member : notAuthorizedRequesterMembersListStr.split(SEPARATOR)) {
-                member = member.trim();
-                
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
-                
-                notAuthorizedTargetMembers.add(member);
-            }
-        }
-        
-        return notAuthorizedTargetMembers;
-    }
-
     @Override
     public boolean isMember(String provider) {
         return this.membersList.contains(provider);
@@ -89,12 +29,11 @@ public class BlockList implements MembershipService {
 
     @Override
     public boolean isTargetAuthorized(String provider) {
-        return isMember(provider) && !this.notAuthorizedTargetMembers.contains(provider);
+        return isMember(provider) && !this.targetMembers.contains(provider);
     }
 
     @Override
     public boolean isRequesterAuthorized(String provider) {
-        return isMember(provider) && !this.notAuthorizedRequesterMembers.contains(provider);
+        return isMember(provider) && !this.requesterMembers.contains(provider);
     }
-
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
@@ -10,8 +10,8 @@ public class BlockList extends MembershipListService implements MembershipServic
     
     public BlockList() throws ConfigurationErrorException {
         membersList = readMembers();
-        targetMembers = readTargetMembers(ConfigurationPropertyKeys.NOT_AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
-        requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.NOT_AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
+        targetMembers = readTargetMembers(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+        requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
     }
 
     /**
@@ -36,4 +36,14 @@ public class BlockList extends MembershipListService implements MembershipServic
     public boolean isRequesterAuthorized(String provider) {
         return isMember(provider) && !this.requesterMembers.contains(provider);
     }
+    
+	@Override
+	public void addTarget(String provider) throws ConfigurationErrorException {
+		addTargetMember(provider, ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+	}
+	
+	@Override
+	public void addRequester(String provider) throws ConfigurationErrorException {
+		addRequesterMember(provider, ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+	}
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
@@ -11,6 +11,8 @@ public class BlockList extends MembershipListService implements MembershipServic
         membersList = readMembers();
         targetMembers = readTargetMembers();
         requesterMembers = readRequesterMembers();
+        
+        validateMembersList();
     }
 
     /**

--- a/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/BlockList.java
@@ -3,15 +3,14 @@ package cloud.fogbow.ms.core.service;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
-import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.MembershipService;
 
 public class BlockList extends MembershipListService implements MembershipService {
     
     public BlockList() throws ConfigurationErrorException {
         membersList = readMembers();
-        targetMembers = readTargetMembers(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        requesterMembers = readRequesterMembers(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+        targetMembers = readTargetMembers();
+        requesterMembers = readRequesterMembers();
     }
 
     /**
@@ -36,14 +35,4 @@ public class BlockList extends MembershipListService implements MembershipServic
     public boolean isRequesterAuthorized(String provider) {
         return isMember(provider) && !this.requesterMembers.contains(provider);
     }
-    
-	@Override
-	public void addTarget(String provider) throws ConfigurationErrorException {
-		addTargetMember(provider, ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-	}
-	
-	@Override
-	public void addRequester(String provider) throws ConfigurationErrorException {
-		addRequesterMember(provider, ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-	}
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.constants.Messages;
 import cloud.fogbow.ms.core.MembershipService;
@@ -77,17 +78,21 @@ public abstract class MembershipListService implements MembershipService {
 	}
 	
 	@Override
-	public void addMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException {
-        if (isMember(provider)) {
+	public void addMember(ProviderPermission permission) throws ConfigurationErrorException {
+	    String provider = permission.getProvider();
+	    boolean isTarget = permission.isTarget();
+	    boolean isRequester = permission.isRequester();
+	    
+        if (isMember(permission.getProvider())) {
             throw new ConfigurationErrorException(Messages.Exception.PROVIDER_IS_ALREADY_A_MEMBER);
         }
         
-        validateProviderProperties(target, requester);
+        validateProviderProperties(isTarget, isRequester);
 
         membersList.add(provider);
         
-        updateProviderList(targetMembers, provider, target);
-        updateProviderList(requesterMembers, provider, requester);
+        updateProviderList(targetMembers, provider, isTarget);
+        updateProviderList(requesterMembers, provider, isRequester);
         
         updateConfigurationFile();
 	}
@@ -104,12 +109,16 @@ public abstract class MembershipListService implements MembershipService {
 	}
 
 	@Override
-	public void updateMember(String provider, boolean target, boolean requester) throws ConfigurationErrorException {
+	public void updateMember(ProviderPermission permission) throws ConfigurationErrorException {
+        String provider = permission.getProvider();
+        boolean isTarget = permission.isTarget();
+        boolean isRequester = permission.isRequester();
+ 
 	    checkProviderIsMember(provider);
-	    validateProviderProperties(target, requester);
+	    validateProviderProperties(isTarget, isRequester);
 	    
-	    updateProviderList(targetMembers, provider, target);
-	    updateProviderList(requesterMembers, provider, requester);
+	    updateProviderList(targetMembers, provider, isTarget);
+	    updateProviderList(requesterMembers, provider, isRequester);
 	    
 	    updateConfigurationFile();
 	}

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -81,5 +81,37 @@ public abstract class MembershipListService implements MembershipService {
     	
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
+    
+    protected void addTargetMember(String provider, String targetMembersListPropertyKey) throws ConfigurationErrorException {
+    	
+        if (!this.membersList.contains(provider)) {
+            throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
+        }
+        
+        targetMembers.add(provider);
+        
+        String newTargetMembersList = String.join(SEPARATOR, targetMembers);
+        
+    	PropertiesHolder.getInstance().setProperty(targetMembersListPropertyKey, 
+    			newTargetMembersList);
+    	
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+    }
+    
+    protected void addRequesterMember(String provider, String requesterMembersListPropertyKey) throws ConfigurationErrorException {
+    	
+        if (!this.membersList.contains(provider)) {
+            throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
+        }
+        
+        requesterMembers.add(provider);
+        
+        String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
+        
+    	PropertiesHolder.getInstance().setProperty(requesterMembersListPropertyKey, 
+    			newRequesterMembersList);
+    	
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+    }
 
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -45,7 +45,6 @@ public abstract class MembershipListService implements MembershipService {
                 member = member.trim();
                 
                 checkProviderIsMember(member);
-                
                 authorizedTargetMembers.add(member);
             }
         }
@@ -94,25 +93,26 @@ public abstract class MembershipListService implements MembershipService {
 	@Override
 	public void addTarget(String provider) throws ConfigurationErrorException {
         checkProviderIsMember(provider);
-        // TODO must check duplicate providers
-        targetMembers.add(provider);
         
-        String newTargetMembersList = String.join(SEPARATOR, targetMembers);
-    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
-    			newTargetMembersList);
-    	PropertiesHolder.getInstance().updatePropertiesFile();
+        if (targetMembers.contains(provider)) {
+        	throw new ConfigurationErrorException(Messages.Exception.PROVIDER_IS_ALREADY_A_TARGET);
+        }
+        
+        targetMembers.add(provider);
+        updateTargetsListOnPropertiesFile();
     }
+
     
 	@Override
 	public void addRequester(String provider) throws ConfigurationErrorException {
         checkProviderIsMember(provider);
-        // TODO must check duplicate providers
-        requesterMembers.add(provider);
         
-        String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
-    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
-    			newRequesterMembersList);
-    	PropertiesHolder.getInstance().updatePropertiesFile();
+        if (requesterMembers.contains(provider)) {
+        	throw new ConfigurationErrorException(Messages.Exception.PROVIDER_IS_ALREADY_A_REQUESTER);
+        }
+        
+        requesterMembers.add(provider);
+        updateRequestersListOnPropertiesFile();
     }
 	
 	@Override
@@ -122,11 +122,7 @@ public abstract class MembershipListService implements MembershipService {
 		}
 		
 		targetMembers.remove(provider);
-		
-        String newTargetMembersList = String.join(SEPARATOR, targetMembers);
-    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
-    			newTargetMembersList);
-    	PropertiesHolder.getInstance().updatePropertiesFile();
+        updateTargetsListOnPropertiesFile();
 	}
 
 	@Override
@@ -136,8 +132,18 @@ public abstract class MembershipListService implements MembershipService {
 		}
 		
 		requesterMembers.remove(provider);
-		
-        String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
+        updateRequestersListOnPropertiesFile();
+	}
+	
+	private void updateTargetsListOnPropertiesFile() {
+		String newTargetMembersList = String.join(SEPARATOR, targetMembers);
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
+    			newTargetMembersList);
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+	}
+	
+	private void updateRequestersListOnPropertiesFile() {
+		String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
     	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
     			newRequesterMembersList);
     	PropertiesHolder.getInstance().updatePropertiesFile();

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -16,7 +16,12 @@ public abstract class MembershipListService implements MembershipService {
     protected List<String> membersList;
     protected List<String> targetMembers;
     protected List<String> requesterMembers;
-	
+
+    public abstract List<String> listMembers() throws Exception;
+    public abstract boolean isMember(String provider);
+    public abstract boolean isTargetAuthorized(String provider);
+    public abstract boolean isRequesterAuthorized(String provider);
+    
     protected List<String> readMembers() {
         List<String> membersList = new ArrayList<>();
 
@@ -89,6 +94,7 @@ public abstract class MembershipListService implements MembershipService {
 	@Override
 	public void addTarget(String provider) throws ConfigurationErrorException {
         checkProviderIsMember(provider);
+        // TODO must check duplicate providers
         targetMembers.add(provider);
         
         String newTargetMembersList = String.join(SEPARATOR, targetMembers);
@@ -100,6 +106,7 @@ public abstract class MembershipListService implements MembershipService {
 	@Override
 	public void addRequester(String provider) throws ConfigurationErrorException {
         checkProviderIsMember(provider);
+        // TODO must check duplicate providers
         requesterMembers.add(provider);
         
         String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
@@ -107,5 +114,33 @@ public abstract class MembershipListService implements MembershipService {
     			newRequesterMembersList);
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
+	
+	@Override
+	public void removeTarget(String provider) throws ConfigurationErrorException {
+		if (!targetMembers.contains(provider)) {
+			throw new ConfigurationErrorException(Messages.Exception.MEMBER_IS_NOT_TARGET);
+		}
+		
+		targetMembers.remove(provider);
+		
+        String newTargetMembersList = String.join(SEPARATOR, targetMembers);
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
+    			newTargetMembersList);
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+	}
+
+	@Override
+	public void removeRequester(String provider) throws ConfigurationErrorException {
+		if (!requesterMembers.contains(provider)) {
+			throw new ConfigurationErrorException(Messages.Exception.MEMBER_IS_NOT_REQUESTER);
+		}
+		
+		requesterMembers.remove(provider);
+		
+        String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
+    			newRequesterMembersList);
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+	}
 
 }

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -123,7 +123,6 @@ public abstract class MembershipListService implements MembershipService {
 	    updateConfigurationFile();
 	}
 	
-	// TODO test this
 	protected void validateMembersList() throws ConfigurationErrorException {
 	    for (String provider : membersList) {
 	        validateProviderProperties(targetMembers.contains(provider), requesterMembers.contains(provider));

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -1,0 +1,85 @@
+package cloud.fogbow.ms.core.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ms.constants.Messages;
+import cloud.fogbow.ms.core.MembershipService;
+import cloud.fogbow.ms.core.PropertiesHolder;
+
+public abstract class MembershipListService implements MembershipService {
+
+    protected static final String SEPARATOR = ",";
+
+    protected List<String> membersList;
+    protected List<String> targetMembers;
+    protected List<String> requesterMembers;
+	
+    protected List<String> readMembers() {
+        List<String> membersList = new ArrayList<>();
+
+        String membersListStr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
+        for (String member : membersListStr.split(SEPARATOR)) {
+            member = member.trim();
+            membersList.add(member);
+        }
+
+        return membersList;
+    }
+    
+    protected List<String> readTargetMembers(String targetMembersListPropertyKey) throws ConfigurationErrorException {
+        List<String> authorizedTargetMembers = new ArrayList<String>();
+        
+        String authorizedTargetMembersListStr = PropertiesHolder.getInstance().getProperty(targetMembersListPropertyKey);
+        
+        if (!authorizedTargetMembersListStr.isEmpty()) {
+            for (String member : authorizedTargetMembersListStr.split(SEPARATOR)) {
+                member = member.trim();
+                
+                if (!this.membersList.contains(member)) {
+                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
+                }
+                
+                authorizedTargetMembers.add(member);
+            }
+        }
+        
+        return authorizedTargetMembers;
+    }
+    
+    protected List<String> readRequesterMembers(String requesterMembersListPropertyKey) throws ConfigurationErrorException {
+        List<String> authorizedRequesterMembers = new ArrayList<String>();
+        
+        String authorizedRequesterMembersListStr = PropertiesHolder.getInstance().getProperty(requesterMembersListPropertyKey);
+        
+        if (!authorizedRequesterMembersListStr.isEmpty()) {
+            for (String member : authorizedRequesterMembersListStr.split(SEPARATOR)) {
+                member = member.trim();
+                
+                if (!this.membersList.contains(member)) {
+                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
+                }
+                
+                authorizedRequesterMembers.add(member);
+            }
+        }
+        
+        return authorizedRequesterMembers;
+    }
+    
+    @Override
+    public void addMember(String provider) {
+    	// TODO add provider name validation
+    	membersList.add(provider);
+    	
+    	String newMembersString = String.join(SEPARATOR, membersList);
+    	
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, 
+    			newMembersString);
+    	
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -89,6 +89,28 @@ public abstract class MembershipListService implements MembershipService {
     			newMembersString);
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
+    
+	@Override
+	public void removeMember(String provider) throws ConfigurationErrorException {
+		checkProviderIsMember(provider);
+		
+		targetMembers.remove(provider);
+		requesterMembers.remove(provider);
+		membersList.remove(provider);
+		
+		String newTargetMembersList = String.join(SEPARATOR, targetMembers);
+		String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
+		String newMembersString = String.join(SEPARATOR, membersList);
+		
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
+    			newTargetMembersList);
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
+    			newRequesterMembersList);
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, 
+    			newMembersString);
+    	
+    	PropertiesHolder.getInstance().updatePropertiesFile();
+	}
 
 	@Override
 	public void addTarget(String provider) throws ConfigurationErrorException {
@@ -102,7 +124,6 @@ public abstract class MembershipListService implements MembershipService {
         updateTargetsListOnPropertiesFile();
     }
 
-    
 	@Override
 	public void addRequester(String provider) throws ConfigurationErrorException {
         checkProviderIsMember(provider);

--- a/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
+++ b/src/main/java/cloud/fogbow/ms/core/service/MembershipListService.java
@@ -29,18 +29,17 @@ public abstract class MembershipListService implements MembershipService {
         return membersList;
     }
     
-    protected List<String> readTargetMembers(String targetMembersListPropertyKey) throws ConfigurationErrorException {
+    protected List<String> readTargetMembers() throws ConfigurationErrorException {
         List<String> authorizedTargetMembers = new ArrayList<String>();
         
-        String authorizedTargetMembersListStr = PropertiesHolder.getInstance().getProperty(targetMembersListPropertyKey);
+        String authorizedTargetMembersListStr = PropertiesHolder.getInstance().
+        		getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
         
         if (!authorizedTargetMembersListStr.isEmpty()) {
             for (String member : authorizedTargetMembersListStr.split(SEPARATOR)) {
                 member = member.trim();
                 
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
+                checkProviderIsMember(member);
                 
                 authorizedTargetMembers.add(member);
             }
@@ -49,68 +48,63 @@ public abstract class MembershipListService implements MembershipService {
         return authorizedTargetMembers;
     }
     
-    protected List<String> readRequesterMembers(String requesterMembersListPropertyKey) throws ConfigurationErrorException {
+    protected List<String> readRequesterMembers() throws ConfigurationErrorException {
         List<String> authorizedRequesterMembers = new ArrayList<String>();
         
-        String authorizedRequesterMembersListStr = PropertiesHolder.getInstance().getProperty(requesterMembersListPropertyKey);
+        String authorizedRequesterMembersListStr = PropertiesHolder.getInstance().
+        		getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
         
         if (!authorizedRequesterMembersListStr.isEmpty()) {
             for (String member : authorizedRequesterMembersListStr.split(SEPARATOR)) {
                 member = member.trim();
                 
-                if (!this.membersList.contains(member)) {
-                    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-                }
-                
+                checkProviderIsMember(member);
                 authorizedRequesterMembers.add(member);
             }
         }
         
         return authorizedRequesterMembers;
     }
+
+	private void checkProviderIsMember(String member) throws ConfigurationErrorException {
+		if (!isMember(member)) {
+		    throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
+		}
+	}
     
     @Override
-    public void addMember(String provider) {
-    	// TODO add provider name validation
+    public void addMember(String provider) throws ConfigurationErrorException {
+    	if (isMember(provider)) {
+    		throw new ConfigurationErrorException(Messages.Exception.PROVIDER_IS_ALREADY_A_MEMBER);
+    	}
+    	
     	membersList.add(provider);
     	
     	String newMembersString = String.join(SEPARATOR, membersList);
-    	
     	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, 
     			newMembersString);
-    	
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
-    
-    protected void addTargetMember(String provider, String targetMembersListPropertyKey) throws ConfigurationErrorException {
-    	
-        if (!this.membersList.contains(provider)) {
-            throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-        }
-        
+
+	@Override
+	public void addTarget(String provider) throws ConfigurationErrorException {
+        checkProviderIsMember(provider);
         targetMembers.add(provider);
         
         String newTargetMembersList = String.join(SEPARATOR, targetMembers);
-        
-    	PropertiesHolder.getInstance().setProperty(targetMembersListPropertyKey, 
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, 
     			newTargetMembersList);
-    	
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
     
-    protected void addRequesterMember(String provider, String requesterMembersListPropertyKey) throws ConfigurationErrorException {
-    	
-        if (!this.membersList.contains(provider)) {
-            throw new ConfigurationErrorException(Messages.Exception.INVALID_MEMBER_NAME);
-        }
-        
+	@Override
+	public void addRequester(String provider) throws ConfigurationErrorException {
+        checkProviderIsMember(provider);
         requesterMembers.add(provider);
         
         String newRequesterMembersList = String.join(SEPARATOR, requesterMembers);
-        
-    	PropertiesHolder.getInstance().setProperty(requesterMembersListPropertyKey, 
+    	PropertiesHolder.getInstance().setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
     			newRequesterMembersList);
-    	
     	PropertiesHolder.getInstance().updatePropertiesFile();
     }
 

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -1,0 +1,192 @@
+package cloud.fogbow.ms.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import cloud.fogbow.as.core.util.AuthenticationUtil;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
+import cloud.fogbow.common.util.PublicKeysHolder;
+import cloud.fogbow.ms.core.authorization.AdminAuthorizationPlugin;
+import cloud.fogbow.ms.core.authorization.AdminOperation;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AuthenticationUtil.class, MSPublicKeysHolder.class, 
+	PropertiesHolder.class, PublicKeysHolder.class})
+public class ApplicationFacadeTest {
+
+	private ApplicationFacade facade;
+	private MembershipService membershipService;
+	private AuthorizationPlugin<AdminOperation> authorizationPlugin;
+	private String member1 = "member1";
+	private String member2 = "member2";
+	private List<String> members = Arrays.asList(member1, member2);
+	
+    private String token = "userToken";
+    private String userId = "userId";
+    private String userName = "userName";
+    private String provider = "provider";
+	
+	private SystemUser systemUser; 
+	private RSAPublicKey key;
+	private AdminOperation operation;
+
+    @Before
+    public void setUp() throws FogbowException {
+		this.operation = new AdminOperation();
+		this.systemUser = new SystemUser(userId, userName, provider);
+		
+		// authentication
+		this.key = Mockito.mock(RSAPublicKey.class);
+
+		PowerMockito.mockStatic(MSPublicKeysHolder.class);
+		MSPublicKeysHolder keysHolder = Mockito.mock(MSPublicKeysHolder.class);
+		Mockito.doReturn(key).when(keysHolder).getAsPublicKey();
+		BDDMockito.given(MSPublicKeysHolder.getInstance()).willReturn(keysHolder);
+		
+		PowerMockito.mockStatic(AuthenticationUtil.class);
+		BDDMockito.given(AuthenticationUtil.authenticate(key, token)).willReturn(systemUser);
+		
+		// authorization
+		this.authorizationPlugin = Mockito.mock(AdminAuthorizationPlugin.class);
+		Mockito.doReturn(true).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.membershipService = Mockito.mock(MembershipService.class);
+		
+		this.facade = ApplicationFacade.getInstance();
+		
+		this.facade.setMembershipService(membershipService);
+		this.facade.setAuthorizationPlugin(authorizationPlugin);
+    }
+	
+	// TODO documentation
+	@Test
+	public void testListMembers() throws Exception {
+		this.facade = ApplicationFacade.getInstance();
+		
+		Mockito.doReturn(members).when(this.membershipService).listMembers();
+		
+		List<String> returnedMembersList = facade.listMembers();
+		
+		assertEquals(returnedMembersList.size(), 2);
+		assertTrue(returnedMembersList.contains(member1));
+		assertTrue(returnedMembersList.contains(member2));
+	}
+	
+	// TODO documentation
+	@Test
+	public void testAddProvider() throws FogbowException {
+		this.facade.addProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).addMember(provider);
+	}
+	
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testAddProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.addProvider(token, provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testRemoveProvider() throws FogbowException {
+		this.facade.removeProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).removeMember(provider);
+	}
+
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testRemoveProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.removeProvider(token, provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testAddTargetProvider() throws FogbowException {
+		this.facade.addTargetProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).addTarget(provider);
+	}
+	
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testAddTargetProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.addTargetProvider(token, provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testRemoveTarget() throws FogbowException {
+		this.facade.removeTargetProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).removeTarget(provider);
+	}
+	
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testRemoveTargetProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.removeTargetProvider(token, provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testAddRequesterProvider() throws FogbowException {
+		this.facade.addRequesterProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).addRequester(provider);
+	}
+	
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testAddRequesterProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.addRequesterProvider(token, provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testRemoveRequesterProvider() throws FogbowException {
+		this.facade.removeRequesterProvider(token, provider);
+		
+		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+		Mockito.verify(membershipService, Mockito.times(1)).removeRequester(provider);
+	}
+	
+	// TODO documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testRemoveRequesterProviderUnauthorizedOperation() throws FogbowException {
+		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
+		
+		this.facade.removeRequesterProvider(token, provider);
+	}
+}

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -140,7 +140,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(this.membershipService, Mockito.times(1)).listMembers();
 	}
 	
-	// TODO documentation
+	// test case: When invoking the isTargetAuthorized method, 
+	// it must call the isTargetAuthorized method of the MembershipService
+	// instance it holds.
     @Test
     public void testIsTargetAuthorized() {
         Mockito.doReturn(true).when(this.membershipService).isTargetAuthorized(provider);
@@ -150,7 +152,9 @@ public class ApplicationFacadeTest {
         Mockito.verify(membershipService, Mockito.times(1)).isTargetAuthorized(provider);
     }
 	
-	// TODO documentation
+    // test case: When invoking the isRequesterAuthorized method, 
+    // it must call the isRequesterAuthorized method of the MembershipService
+    // instance it holds.
 	@Test
 	public void testIsRequesterAuthorized() {
 	    Mockito.doReturn(true).when(this.membershipService).isRequesterAuthorized(provider);
@@ -200,7 +204,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).removeMember(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the updateProvider method, it must
+	// authorize the operation and call the updateMember method of
+	// the MembershipService instance it holds.
 	@Test
 	public void testUpdateProvider() throws FogbowException {
         boolean target = true;

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -79,7 +79,7 @@ public class ApplicationFacadeTest {
 		this.facade.setMembershipService(membershipService);
 		this.facade.setAuthorizationPlugin(authorizationPlugin);
     }
-	
+    
     // test case: When invoking the updateMembershipService method, it must 
     // authorize the operation, call the PluginInstantiator to get a new 
     // MembershipService instance and set this instance as the one used 
@@ -140,6 +140,26 @@ public class ApplicationFacadeTest {
 		Mockito.verify(this.membershipService, Mockito.times(1)).listMembers();
 	}
 	
+	// TODO documentation
+    @Test
+    public void testIsTargetAuthorized() {
+        Mockito.doReturn(true).when(this.membershipService).isTargetAuthorized(provider);
+        
+        assertTrue(this.facade.isTargetAuthorized(provider));
+        
+        Mockito.verify(membershipService, Mockito.times(1)).isTargetAuthorized(provider);
+    }
+	
+	// TODO documentation
+	@Test
+	public void testIsRequesterAuthorized() {
+	    Mockito.doReturn(true).when(this.membershipService).isRequesterAuthorized(provider);
+	    
+	    assertTrue(this.facade.isRequesterAuthorized(provider));
+	    
+	    Mockito.verify(membershipService, Mockito.times(1)).isRequesterAuthorized(provider);
+	}
+	
 	// test case: When invoking the addProvider method, it must 
 	// authorize the operation and call the addMember method of 
 	// the MembershipService instance it holds.
@@ -178,6 +198,19 @@ public class ApplicationFacadeTest {
 		
 		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
 		Mockito.verify(membershipService, Mockito.times(1)).removeMember(provider);
+	}
+	
+	// TODO documentation
+	@Test
+	public void testUpdateProvider() throws FogbowException {
+        boolean target = true;
+        boolean requester = true;
+        ProviderPermission permission = new ProviderPermission(provider, target, requester);
+
+        this.facade.updateProvider(token, permission);
+
+        Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
+        Mockito.verify(membershipService, Mockito.times(1)).updateMember(permission);
 	}
 
 	// test case: When invoking the removeProvider method and 

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -24,7 +24,7 @@ import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.PublicKeysHolder;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.authorization.AdminAuthorizationPlugin;
-import cloud.fogbow.ms.core.authorization.AdminOperation;
+import cloud.fogbow.ms.core.authorization.MsOperation;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({AuthenticationUtil.class, MSPublicKeysHolder.class, 
@@ -34,7 +34,7 @@ public class ApplicationFacadeTest {
 
 	private ApplicationFacade facade;
 	private MembershipService membershipService;
-	private AuthorizationPlugin<AdminOperation> authorizationPlugin;
+	private AuthorizationPlugin<MsOperation> authorizationPlugin;
 	private String member1 = "member1";
 	private String member2 = "member2";
 	private List<String> members = Arrays.asList(member1, member2);
@@ -48,12 +48,12 @@ public class ApplicationFacadeTest {
 	
 	private SystemUser systemUser; 
 	private RSAPublicKey key;
-	private AdminOperation operation;
+	private MsOperation operation;
     private PropertiesHolder propertiesHolder;
 
     @Before
     public void setUp() throws FogbowException {
-		this.operation = new AdminOperation();
+		this.operation = new MsOperation();
 		this.systemUser = new SystemUser(userId, userName, provider);
 		
 		// authentication

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -74,7 +74,10 @@ public class ApplicationFacadeTest {
 		this.facade.setAuthorizationPlugin(authorizationPlugin);
     }
 	
-	// TODO documentation
+	// test case: When invoking the listMembers method, it
+    // must call the listMembers method of the MembershipService
+    // instance it holds and return a list containing the same
+    // elements.
 	@Test
 	public void testListMembers() throws Exception {
 		this.facade = ApplicationFacade.getInstance();
@@ -86,9 +89,13 @@ public class ApplicationFacadeTest {
 		assertEquals(returnedMembersList.size(), 2);
 		assertTrue(returnedMembersList.contains(member1));
 		assertTrue(returnedMembersList.contains(member2));
+		
+		Mockito.verify(this.membershipService, Mockito.times(1)).listMembers();
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addProvider method, it must 
+	// authorize the operation and call the addMember method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testAddProvider() throws FogbowException {
 		this.facade.addProvider(token, provider);
@@ -97,7 +104,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).addMember(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testAddProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
@@ -105,7 +114,9 @@ public class ApplicationFacadeTest {
 		this.facade.addProvider(token, provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the removeProvider method, it must 
+	// authorize the operation and call the removeMember method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testRemoveProvider() throws FogbowException {
 		this.facade.removeProvider(token, provider);
@@ -114,7 +125,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).removeMember(provider);
 	}
 
-	// TODO documentation
+	// test case: When invoking the removeProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testRemoveProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
@@ -122,7 +135,9 @@ public class ApplicationFacadeTest {
 		this.facade.removeProvider(token, provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addTargetProvider method, it must 
+	// authorize the operation and call the addTarget method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testAddTargetProvider() throws FogbowException {
 		this.facade.addTargetProvider(token, provider);
@@ -131,7 +146,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).addTarget(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addTargetProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testAddTargetProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
@@ -139,7 +156,9 @@ public class ApplicationFacadeTest {
 		this.facade.addTargetProvider(token, provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the removeTargetProvider method, it must 
+	// authorize the operation and call the removeTarget method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testRemoveTarget() throws FogbowException {
 		this.facade.removeTargetProvider(token, provider);
@@ -148,7 +167,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).removeTarget(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the removeTargetProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testRemoveTargetProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
@@ -156,7 +177,9 @@ public class ApplicationFacadeTest {
 		this.facade.removeTargetProvider(token, provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addRequesterProvider method, it must 
+	// authorize the operation and call the addRequester method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testAddRequesterProvider() throws FogbowException {
 		this.facade.addRequesterProvider(token, provider);
@@ -165,7 +188,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).addRequester(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the addRequesterProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testAddRequesterProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
@@ -173,7 +198,9 @@ public class ApplicationFacadeTest {
 		this.facade.addRequesterProvider(token, provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the removeRequesterProvider method, it must 
+	// authorize the operation and call the removeRequester method of 
+	// the MembershipService instance it holds.
 	@Test
 	public void testRemoveRequesterProvider() throws FogbowException {
 		this.facade.removeRequesterProvider(token, provider);
@@ -182,7 +209,9 @@ public class ApplicationFacadeTest {
 		Mockito.verify(membershipService, Mockito.times(1)).removeRequester(provider);
 	}
 	
-	// TODO documentation
+	// test case: When invoking the removeRequesterProvider method and 
+	// the operation is not authorized, it must throw an
+	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testRemoveRequesterProviderUnauthorizedOperation() throws FogbowException {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -22,6 +22,7 @@ import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.common.util.PublicKeysHolder;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.authorization.AdminAuthorizationPlugin;
 import cloud.fogbow.ms.core.authorization.MsOperation;
@@ -146,11 +147,12 @@ public class ApplicationFacadeTest {
 	public void testAddProvider() throws FogbowException {
 	    boolean target = true;
 	    boolean requester = true;
+	    ProviderPermission permission = new ProviderPermission(provider, target, requester);
 	    
-		this.facade.addProvider(token, provider, true, true);
+		this.facade.addProvider(token, permission);
 		
 		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).addMember(provider, target, requester);
+		Mockito.verify(membershipService, Mockito.times(1)).addMember(permission);
 	}
 	
 	// test case: When invoking the addProvider method and 
@@ -160,10 +162,11 @@ public class ApplicationFacadeTest {
 	public void testAddProviderUnauthorizedOperation() throws FogbowException {
         boolean target = true;
         boolean requester = true;
+        ProviderPermission permission = new ProviderPermission(provider, target, requester);
 
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
 		
-		this.facade.addProvider(token, provider, target, requester);
+		this.facade.addProvider(token, permission);
 	}
 	
 	// test case: When invoking the removeProvider method, it must 

--- a/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/ApplicationFacadeTest.java
@@ -144,10 +144,13 @@ public class ApplicationFacadeTest {
 	// the MembershipService instance it holds.
 	@Test
 	public void testAddProvider() throws FogbowException {
-		this.facade.addProvider(token, provider);
+	    boolean target = true;
+	    boolean requester = true;
+	    
+		this.facade.addProvider(token, provider, true, true);
 		
 		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).addMember(provider);
+		Mockito.verify(membershipService, Mockito.times(1)).addMember(provider, target, requester);
 	}
 	
 	// test case: When invoking the addProvider method and 
@@ -155,9 +158,12 @@ public class ApplicationFacadeTest {
 	// UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testAddProviderUnauthorizedOperation() throws FogbowException {
+        boolean target = true;
+        boolean requester = true;
+
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
 		
-		this.facade.addProvider(token, provider);
+		this.facade.addProvider(token, provider, target, requester);
 	}
 	
 	// test case: When invoking the removeProvider method, it must 
@@ -179,89 +185,5 @@ public class ApplicationFacadeTest {
 		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
 		
 		this.facade.removeProvider(token, provider);
-	}
-	
-	// test case: When invoking the addTargetProvider method, it must 
-	// authorize the operation and call the addTarget method of 
-	// the MembershipService instance it holds.
-	@Test
-	public void testAddTargetProvider() throws FogbowException {
-		this.facade.addTargetProvider(token, provider);
-		
-		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).addTarget(provider);
-	}
-	
-	// test case: When invoking the addTargetProvider method and 
-	// the operation is not authorized, it must throw an
-	// UnauthorizedRequestException
-	@Test(expected = UnauthorizedRequestException.class)
-	public void testAddTargetProviderUnauthorizedOperation() throws FogbowException {
-		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
-		
-		this.facade.addTargetProvider(token, provider);
-	}
-	
-	// test case: When invoking the removeTargetProvider method, it must 
-	// authorize the operation and call the removeTarget method of 
-	// the MembershipService instance it holds.
-	@Test
-	public void testRemoveTarget() throws FogbowException {
-		this.facade.removeTargetProvider(token, provider);
-		
-		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).removeTarget(provider);
-	}
-	
-	// test case: When invoking the removeTargetProvider method and 
-	// the operation is not authorized, it must throw an
-	// UnauthorizedRequestException
-	@Test(expected = UnauthorizedRequestException.class)
-	public void testRemoveTargetProviderUnauthorizedOperation() throws FogbowException {
-		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
-		
-		this.facade.removeTargetProvider(token, provider);
-	}
-	
-	// test case: When invoking the addRequesterProvider method, it must 
-	// authorize the operation and call the addRequester method of 
-	// the MembershipService instance it holds.
-	@Test
-	public void testAddRequesterProvider() throws FogbowException {
-		this.facade.addRequesterProvider(token, provider);
-		
-		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).addRequester(provider);
-	}
-	
-	// test case: When invoking the addRequesterProvider method and 
-	// the operation is not authorized, it must throw an
-	// UnauthorizedRequestException
-	@Test(expected = UnauthorizedRequestException.class)
-	public void testAddRequesterProviderUnauthorizedOperation() throws FogbowException {
-		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
-		
-		this.facade.addRequesterProvider(token, provider);
-	}
-	
-	// test case: When invoking the removeRequesterProvider method, it must 
-	// authorize the operation and call the removeRequester method of 
-	// the MembershipService instance it holds.
-	@Test
-	public void testRemoveRequesterProvider() throws FogbowException {
-		this.facade.removeRequesterProvider(token, provider);
-		
-		Mockito.verify(authorizationPlugin, Mockito.times(1)).isAuthorized(systemUser, operation);
-		Mockito.verify(membershipService, Mockito.times(1)).removeRequester(provider);
-	}
-	
-	// test case: When invoking the removeRequesterProvider method and 
-	// the operation is not authorized, it must throw an
-	// UnauthorizedRequestException
-	@Test(expected = UnauthorizedRequestException.class)
-	public void testRemoveRequesterProviderUnauthorizedOperation() throws FogbowException {
-		Mockito.doThrow(new UnauthorizedRequestException()).when(this.authorizationPlugin).isAuthorized(systemUser, operation);
-		
-		this.facade.removeRequesterProvider(token, provider);
 	}
 }

--- a/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
@@ -21,7 +21,7 @@ import cloud.fogbow.ms.core.PropertiesHolder;
 @PrepareForTest({PropertiesHolder.class})
 public class AdminAuthorizationPluginTest {
 
-	private AuthorizationPlugin<AdminOperation> plugin;
+	private AuthorizationPlugin<MsOperation> plugin;
 	private final String userIdAdmin1 = "userIdAdmin1";
 	private final String userNameAdmin1 = "userNameAdmin1";
 	private final String userIdAdmin2 = "userIdAdmin2";
@@ -39,7 +39,7 @@ public class AdminAuthorizationPluginTest {
 		
 		SystemUser admin1 = new SystemUser(userIdAdmin1, userNameAdmin1, identityProviderId);
 		SystemUser admin2 = new SystemUser(userIdAdmin2, userNameAdmin2, identityProviderId);
-		AdminOperation operation = new AdminOperation();
+		MsOperation operation = new MsOperation();
 		
 		plugin = new AdminAuthorizationPlugin();
 		
@@ -54,7 +54,7 @@ public class AdminAuthorizationPluginTest {
         setUpConfiguration();
 		
 		SystemUser notAdmin = new SystemUser(userIdNotAdmin, userNameNotAdmin, identityProviderId);
-		AdminOperation operation = new AdminOperation();
+		MsOperation operation = new MsOperation();
 		
 		plugin = new AdminAuthorizationPlugin();
 		

--- a/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
@@ -1,0 +1,83 @@
+package cloud.fogbow.ms.core.authorization;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
+import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ms.core.PropertiesHolder;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertiesHolder.class})
+public class AdminAuthorizationPluginTest {
+
+	private AuthorizationPlugin<AdminOperation> plugin;
+	private final String userIdAdmin1 = "userIdAdmin1";
+	private final String userNameAdmin1 = "userNameAdmin1";
+	private final String userIdAdmin2 = "userIdAdmin2";
+	private final String userNameAdmin2 = "userNameAdmin2";
+	private String userIdNotAdmin = "userIdNotAdmin";
+	private String userNameNotAdmin = "userNameNotAdmin";
+	private String identityProviderId = "providerId";
+	private String adminIDsString = String.format("%s,%s", userIdAdmin1, userIdAdmin2);
+	
+	// TODO add documentation
+	@Test
+	public void testIsAuthorizedUserIsAdmin() throws UnauthorizedRequestException, ConfigurationErrorException {
+        setUpConfiguration();
+		
+		SystemUser admin1 = new SystemUser(userIdAdmin1, userNameAdmin1, identityProviderId);
+		SystemUser admin2 = new SystemUser(userIdAdmin2, userNameAdmin2, identityProviderId);
+		AdminOperation operation = new AdminOperation();
+		
+		plugin = new AdminAuthorizationPlugin();
+		
+		assertTrue(plugin.isAuthorized(admin1, operation));
+		assertTrue(plugin.isAuthorized(admin2, operation));
+	}
+	
+	// TODO add documentation
+	@Test(expected = UnauthorizedRequestException.class)
+	public void testIsAuthorizedUserIsNotAdmin() throws UnauthorizedRequestException, ConfigurationErrorException {
+        setUpConfiguration();
+		
+		SystemUser notAdmin = new SystemUser(userIdNotAdmin, userNameNotAdmin, identityProviderId);
+		AdminOperation operation = new AdminOperation();
+		
+		plugin = new AdminAuthorizationPlugin();
+		
+		plugin.isAuthorized(notAdmin, operation);
+	}
+
+	// TODO add documentation
+	@Test(expected = ConfigurationErrorException.class)
+	public void testConfigurationMustSetAtLeastOneAdmin() throws ConfigurationErrorException {
+		String emptyAdminIdsString = "";
+		PowerMockito.mockStatic(PropertiesHolder.class);
+        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
+        Mockito.doReturn(emptyAdminIdsString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.ADMINS_IDS);
+        
+        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+        
+        new AdminAuthorizationPlugin();
+	}
+	
+	private void setUpConfiguration() {
+		PowerMockito.mockStatic(PropertiesHolder.class);
+        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
+        Mockito.doReturn(adminIDsString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.ADMINS_IDS);
+        
+        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+	}
+
+}

--- a/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/authorization/AdminAuthorizationPluginTest.java
@@ -31,7 +31,8 @@ public class AdminAuthorizationPluginTest {
 	private String identityProviderId = "providerId";
 	private String adminIDsString = String.format("%s,%s", userIdAdmin1, userIdAdmin2);
 	
-	// TODO add documentation
+	// test case: When invoking the isAuthorized method with an admin user, 
+	// it must return true
 	@Test
 	public void testIsAuthorizedUserIsAdmin() throws UnauthorizedRequestException, ConfigurationErrorException {
         setUpConfiguration();
@@ -46,7 +47,8 @@ public class AdminAuthorizationPluginTest {
 		assertTrue(plugin.isAuthorized(admin2, operation));
 	}
 	
-	// TODO add documentation
+	// test case: When invoking the isAuthorized method with a non-admin user,
+	// it must throw an UnauthorizedRequestException
 	@Test(expected = UnauthorizedRequestException.class)
 	public void testIsAuthorizedUserIsNotAdmin() throws UnauthorizedRequestException, ConfigurationErrorException {
         setUpConfiguration();
@@ -59,7 +61,9 @@ public class AdminAuthorizationPluginTest {
 		plugin.isAuthorized(notAdmin, operation);
 	}
 
-	// TODO add documentation
+	// test case: When attempting to create an instance of 
+	// AdminAuthorizationPlugin using a configuration file 
+	// with no admins listed, it must throw a ConfigurationErrorException
 	@Test(expected = ConfigurationErrorException.class)
 	public void testConfigurationMustSetAtLeastOneAdmin() throws ConfigurationErrorException {
 		String emptyAdminIdsString = "";

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -208,6 +208,34 @@ public class AllowListTest {
     }
     
     // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingAlreadyKnownProviderMustFail() throws ConfigurationErrorException {
+        setUpAllowListWithDefaultLists();
+        
+        try {
+            this.service.addMember(new ProviderPermission(newTargetMember, true, false));
+        } catch (Exception e) {
+            Assert.fail("This call should not fail.");
+        }
+        
+        this.service.addMember(new ProviderPermission(newTargetMember, true, false));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingNoTargetAndNoRequesterMemberMustFail() throws ConfigurationErrorException {
+        setUpAllowListWithDefaultLists();
+        
+        this.service.addMember(new ProviderPermission(newTargetMember, false, false));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testConstructorMustCheckIfAllMembersHavePermissions( ) throws ConfigurationErrorException {
+        setUpAllowListWithProviderWithNoPermission();
+    }
+    
+    // TODO documentation
     @Test
     public void testUpdateMember() throws Exception {
         setUpAllowListWithDefaultLists();
@@ -231,6 +259,14 @@ public class AllowListTest {
         Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
         Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testUpdatingNotKnownMemberMustFail() throws ConfigurationErrorException {
+        setUpAllowListWithDefaultLists();
+        
+        this.service.updateMember(new ProviderPermission(notMember1, false, true));
     }
     
     // test case: When invoking the removeMember method, it must remove the given provider correctly
@@ -307,10 +343,17 @@ public class AllowListTest {
     }
     
     private void setUpAllowListWithEmptyAllowedTargetsList() throws ConfigurationErrorException {
+        // TODO explain
         setUpAllowList(membersListString, membersListString, emptyAllowedTargetsList);
     }
     
     private void setUpAllowListWithEmptyAllowedRequestersList() throws ConfigurationErrorException {
+     // TODO explain
         setUpAllowList(membersListString, emptyAllowedRequestersList, membersListString);
+    }
+    
+    private void setUpAllowListWithProviderWithNoPermission() throws ConfigurationErrorException {
+        // TODO explain
+        setUpAllowList(membersListString, emptyAllowedRequestersList, allowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -12,6 +12,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.MembershipService;
 import cloud.fogbow.ms.core.PropertiesHolder;
@@ -124,7 +125,7 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
-    
+
     // test case: When invoking the addMember method, it must add the given provider correctly, 
     // so that the change is reflected on the return value of the methods listMembers, isMember, 
     // isTargetAuthorized and isRequesterAuthorized. Also, the configuration file must be updated.
@@ -143,7 +144,7 @@ public class AllowListTest {
         Assert.assertFalse(membersId.contains(newRequesterMember));
         Assert.assertFalse(membersId.contains(newTargetAndRequesterMember));
     	
-    	this.service.addMember(newTargetMember, true, false);
+    	this.service.addMember(new ProviderPermission(newTargetMember, true, false));
     
     	String firstUpdateMembersListString = String.join(",", memberAuthorizedAsRequesterAndTarget, 
                 memberAuthorizedAsRequester, memberAuthorizedAsTarget, 
@@ -153,7 +154,7 @@ public class AllowListTest {
         Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, firstUpdateMembersListString);
         Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
     	
-    	this.service.addMember(newRequesterMember, false, true);
+    	this.service.addMember(new ProviderPermission(newRequesterMember, false, true));
 
         String secondUpdatedMembersListString = String.join(",", memberAuthorizedAsRequesterAndTarget, 
                 memberAuthorizedAsRequester, memberAuthorizedAsTarget, 
@@ -163,7 +164,7 @@ public class AllowListTest {
         Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, secondUpdatedMembersListString);
         Mockito.verify(propertiesHolder, Mockito.times(2)).updatePropertiesFile();
 
-    	this.service.addMember(newTargetAndRequesterMember, true, true);
+    	this.service.addMember(new ProviderPermission(newTargetAndRequesterMember, true, true));
     	
         String thirdUpdatedMembersListString = String.join(",", memberAuthorizedAsRequesterAndTarget, 
                 memberAuthorizedAsRequester, memberAuthorizedAsTarget, 
@@ -220,8 +221,8 @@ public class AllowListTest {
         Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
         
-        this.service.updateMember(memberAuthorizedAsTarget, false, true);
-        this.service.updateMember(memberAuthorizedAsRequester, true, false);
+        this.service.updateMember(new ProviderPermission(memberAuthorizedAsTarget, false, true));
+        this.service.updateMember(new ProviderPermission(memberAuthorizedAsRequester, true, false));
         
         Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
         Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -50,6 +50,8 @@ public class AllowListTest {
     private String emptyAllowedTargetsList = "";
     private String emptyAllowedRequestersList = "";
     
+    private PropertiesHolder propertiesHolder;
+    
     // test case: When invoking the listMembers method from an instance created with
     // the MembershipService class constructor with a valid parameter, it must list
     // the configured membership in the file passed by parameter.
@@ -136,15 +138,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test
     public void testAddMember() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new AllowList();
+    	setUpAllowListWithDefaultLists();
     	
     	List<String> membersId = this.service.listMembers();
     	
@@ -174,15 +168,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test
     public void testAddTarget() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(targetsListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new AllowList();
+    	setUpAllowListWithTargetListToBeUpdated();
     	
         Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
         Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
@@ -206,15 +192,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddNotKnownTargetMustFail() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(targetsListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new AllowList();
+    	setUpAllowListWithTargetListToBeUpdated();
         
         this.service.addTarget(notMember1);
     }
@@ -222,15 +200,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(requestersListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new AllowList();
+    	setUpAllowListWithRequesterListToBeUpdated();
     	
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
         Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
@@ -254,27 +224,19 @@ public class AllowListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(requestersListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new AllowList();
+    	setUpAllowListWithRequesterListToBeUpdated();
         
         this.service.addRequester(notMember1);
     }
     
     private void setUpAllowList(String membersListString, String allowedRequestersListString, String allowedTargetsListString) throws ConfigurationErrorException {
         PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedRequestersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(allowedTargetsListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+        this.propertiesHolder = Mockito.mock(PropertiesHolder.class);
+        Mockito.doReturn(membersListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
+        Mockito.doReturn(allowedRequestersListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+        Mockito.doReturn(allowedTargetsListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
         
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(this.propertiesHolder);
         
         this.service = new AllowList();
     }
@@ -289,5 +251,13 @@ public class AllowListTest {
     
     private void setUpAllowListWithEmptyAllowedRequestersList() throws ConfigurationErrorException {
         setUpAllowList(membersListString, emptyAllowedRequestersList, allowedTargetsList);
+    }
+    
+    private void setUpAllowListWithTargetListToBeUpdated() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, allowedRequestersList, targetsListToBeUpdated);
+    }
+    
+    private void setUpAllowListWithRequesterListToBeUpdated() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, requestersListToBeUpdated, allowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -205,6 +205,20 @@ public class AllowListTest {
         this.service.addTarget(notMember1);
     }
     
+    // TODO add documentation   
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingDuplicateTargetMustFail() throws Exception {
+    	setUpAllowListWithTargetListBeforeAdd();
+    	
+    	try {
+	        this.service.addTarget(memberAuthorizedAsTarget);
+		} catch (Exception e) {
+			Assert.fail("This call should not throw exception.");
+		}
+        
+        this.service.addTarget(memberAuthorizedAsTarget);
+    }
+    
     // TODO add documentation
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
@@ -236,6 +250,20 @@ public class AllowListTest {
     	setUpAllowListWithRequesterListBeforeAdd();
         
         this.service.addRequester(notMember1);
+    }
+    
+    // TODO add documentation   
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingDuplicateRequesterMustFail() throws Exception {
+    	setUpAllowListWithRequesterListBeforeAdd();
+        
+    	try {
+    		this.service.addRequester(memberAuthorizedAsRequester);
+    	} catch (Exception e) {
+    		Assert.fail("This call should not throw exception.");
+    	}
+    	
+        this.service.addRequester(memberAuthorizedAsRequester);
     }
     
     // TODO add documentation

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -26,12 +26,16 @@ public class AllowListTest {
     private String memberAuthorizedAsRequester = "requester";
     private String memberAuthorizedAsTarget = "target";
     private String notMember1 = "notMember1";
+    private String newMember = "newMember";
     private String membersListString = String.join(",", memberAuthorizedAsRequesterAndTarget, 
                                         memberAuthorizedAsRequester, memberAuthorizedAsTarget);
     private String allowedRequestersList = String.join(",", memberAuthorizedAsRequester, 
                                         memberAuthorizedAsRequesterAndTarget);
     private String allowedTargetsList = String.join(",", memberAuthorizedAsTarget, 
                                         memberAuthorizedAsRequesterAndTarget);
+    private String updatedMembersListString = String.join(",", memberAuthorizedAsRequesterAndTarget, 
+            							memberAuthorizedAsRequester, memberAuthorizedAsTarget, 
+            							newMember);
     private String emptyAllowedTargetsList = "";
     private String emptyAllowedRequestersList = "";
     
@@ -116,6 +120,44 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
         Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
+    }
+    
+    // TODO add documentation
+    @Test
+    public void testAddMember() throws Exception {
+        PowerMockito.mockStatic(PropertiesHolder.class);
+        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
+        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
+        Mockito.doReturn(allowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.AUTHORIZED_REQUESTER_MEMBERS_LIST_KEY);
+        Mockito.doReturn(allowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.AUTHORIZED_TARGET_MEMBERS_LIST_KEY);
+        
+        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+    	
+    	this.service = new AllowList();
+    	
+    	List<String> membersId = this.service.listMembers();
+    	
+        // verify before adding member
+        Assert.assertEquals(3, membersId.size());
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsRequester));
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsTarget));
+        Assert.assertFalse(membersId.contains(newMember));
+    	
+    	this.service.addMember(newMember);
+    	
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, updatedMembersListString);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+    	
+        List<String> updateMembersId = this.service.listMembers();
+
+        // verify after adding member
+        Assert.assertEquals(4, updateMembersId.size());
+        Assert.assertTrue(updateMembersId.contains(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(updateMembersId.contains(memberAuthorizedAsRequester));
+        Assert.assertTrue(updateMembersId.contains(memberAuthorizedAsTarget));
+        Assert.assertTrue(updateMembersId.contains(newMember));
     }
     
     private void setUpAllowList(String membersListString, String allowedRequestersListString, String allowedTargetsListString) throws ConfigurationErrorException {

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -143,7 +143,9 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addMember method, it must add the given provider correctly, 
+    // so that the change is reflected on the return value of the method listMembers. Also, 
+    // the configuration file must be updated.
     @Test
     public void testAddMember() throws Exception {
     	setUpAllowListWithDefaultLists();
@@ -173,7 +175,9 @@ public class AllowListTest {
         Assert.assertTrue(updateMembersId.contains(newMember));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeMember method, it must remove the given provider correctly
+    // from all internal lists, so that the change is reflected on the return value of the methods listMembers, 
+    // isTargetAuthorized and isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveMember() throws Exception {
     	setUpAllowListWithDefaultLists();
@@ -219,7 +223,8 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeMember method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingNotKnownMemberMustFail() throws ConfigurationErrorException {
     	setUpAllowListWithDefaultLists();
@@ -227,7 +232,9 @@ public class AllowListTest {
     	this.service.removeMember(notMember1);
     }
     
-    // TODO add documentation
+    // test case: When invoking the addTarget method, it must add the given provider 
+    // as target correctly, so that the change is reflected on the return value of the 
+    // method isTargetAuthorized. Also, the configuration file must be updated.
     @Test
     public void testAddTarget() throws Exception {
     	setUpAllowListWithTargetListBeforeAdd();
@@ -251,7 +258,8 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isTargetAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addTarget method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownTargetMustFail() throws Exception {
     	setUpAllowListWithTargetListBeforeAdd();
@@ -259,7 +267,8 @@ public class AllowListTest {
         this.service.addTarget(notMember1);
     }
     
-    // TODO add documentation   
+    // test case: When invoking the addTarget method with a provider which is already 
+    // in the target providers list, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingDuplicateTargetMustFail() throws Exception {
     	setUpAllowListWithTargetListBeforeAdd();
@@ -273,7 +282,9 @@ public class AllowListTest {
         this.service.addTarget(memberAuthorizedAsTarget);
     }
     
-    // TODO add documentation
+    // test case: When invoking the addRequester method, it must add the given provider 
+    // as requester correctly, so that the change is reflected on the return value of the 
+    // method isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
     	setUpAllowListWithRequesterListBeforeAdd();
@@ -298,7 +309,8 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addRequester method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
     	setUpAllowListWithRequesterListBeforeAdd();
@@ -306,7 +318,8 @@ public class AllowListTest {
         this.service.addRequester(notMember1);
     }
     
-    // TODO add documentation   
+    // test case: When invoking the addRequester method with a provider which is already 
+    // in the requester providers list, it must throw a ConfigurationErrorException.   
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingDuplicateRequesterMustFail() throws Exception {
     	setUpAllowListWithRequesterListBeforeAdd();
@@ -320,7 +333,9 @@ public class AllowListTest {
         this.service.addRequester(memberAuthorizedAsRequester);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeTarget method, it must remove the given provider 
+    // from the targets list correctly, so that the change is reflected on the return value of the 
+    // method isTargetAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveTarget() throws Exception {
     	setUpAllowListWithTargetListBeforeRemove();
@@ -344,7 +359,8 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isTargetAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeTarget method with a provider 
+    // which is not a target, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownTargetMustFail() throws Exception {
     	setUpAllowListWithTargetListBeforeRemove();
@@ -352,7 +368,8 @@ public class AllowListTest {
         this.service.removeTarget(memberAuthorizedAsRequester);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeTarget with an unknown provider,
+    // it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownProviderFromTargetsMustFail() throws Exception {
     	setUpAllowListWithTargetListBeforeRemove();
@@ -360,7 +377,9 @@ public class AllowListTest {
         this.service.removeTarget(notMember1);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester method, it must remove the given provider 
+    // from the requesters list correctly, so that the change is reflected on the return value of the 
+    // method isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveRequester() throws Exception {
     	setUpAllowListWithRequestersListBeforeRemove();
@@ -384,7 +403,8 @@ public class AllowListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester method with a provider 
+    // which is not a requester, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownRequesterMustFail() throws Exception {
     	setUpAllowListWithRequestersListBeforeRemove();
@@ -392,7 +412,8 @@ public class AllowListTest {
         this.service.removeRequester(memberAuthorizedAsTarget);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester with an unknown provider,
+    // it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownProviderFromRequestersMustFail() throws Exception {
     	setUpAllowListWithRequestersListBeforeRemove();

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -39,19 +39,27 @@ public class AllowListTest {
             							memberAuthorizedAsRequester, memberAuthorizedAsTarget, 
             							newMember);
     
-    private String targetsListToBeUpdated = memberAuthorizedAsRequesterAndTarget;
-    private String updatedTargetsList = String.join(",", memberAuthorizedAsRequesterAndTarget, 
+    private String targetsListBeforeAdd = memberAuthorizedAsRequesterAndTarget;
+    private String targetsListAfterAdd = String.join(",", memberAuthorizedAsRequesterAndTarget, 
     									memberAuthorizedAsTarget);
     
-    private String requestersListToBeUpdated = memberAuthorizedAsRequesterAndTarget;
-    private String updatedRequestersList = String.join(",", memberAuthorizedAsRequesterAndTarget, 
+    private String requestersListBeforeAdd = memberAuthorizedAsRequesterAndTarget;
+    private String requestersListAfterAdd = String.join(",", memberAuthorizedAsRequesterAndTarget, 
     									memberAuthorizedAsRequester);
+    
+    private String targetsListBeforeRemove = String.join(",", memberAuthorizedAsTarget, 
+            							memberAuthorizedAsRequesterAndTarget);
+    private String targetsListAfterRemove = memberAuthorizedAsRequesterAndTarget;
+    
+    private String requestersListBeforeRemove = String.join(",", memberAuthorizedAsRequester, 
+            							memberAuthorizedAsRequesterAndTarget);
+    private String requestersListAfterRemove = memberAuthorizedAsRequesterAndTarget;
     
     private String emptyAllowedTargetsList = "";
     private String emptyAllowedRequestersList = "";
     
     private PropertiesHolder propertiesHolder;
-    
+
     // test case: When invoking the listMembers method from an instance created with
     // the MembershipService class constructor with a valid parameter, it must list
     // the configured membership in the file passed by parameter.
@@ -168,7 +176,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test
     public void testAddTarget() throws Exception {
-    	setUpAllowListWithTargetListToBeUpdated();
+    	setUpAllowListWithTargetListBeforeAdd();
     	
         Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
         Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
@@ -179,7 +187,7 @@ public class AllowListTest {
         this.service.addTarget(memberAuthorizedAsTarget);
         
     	// verify configuration is update
-    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, updatedTargetsList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, targetsListAfterAdd);
     	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
         
         Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
@@ -191,8 +199,8 @@ public class AllowListTest {
     
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
-    public void testAddNotKnownTargetMustFail() throws Exception {
-    	setUpAllowListWithTargetListToBeUpdated();
+    public void testAddingNotKnownTargetMustFail() throws Exception {
+    	setUpAllowListWithTargetListBeforeAdd();
         
         this.service.addTarget(notMember1);
     }
@@ -200,7 +208,7 @@ public class AllowListTest {
     // TODO add documentation
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
-    	setUpAllowListWithRequesterListToBeUpdated();
+    	setUpAllowListWithRequesterListBeforeAdd();
     	
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
         Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
@@ -211,7 +219,8 @@ public class AllowListTest {
         this.service.addRequester(memberAuthorizedAsRequester);
         
     	// verify configuration is update
-    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, updatedRequestersList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
+    			requestersListAfterAdd);
     	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
         
         Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
@@ -224,9 +233,89 @@ public class AllowListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
-    	setUpAllowListWithRequesterListToBeUpdated();
+    	setUpAllowListWithRequesterListBeforeAdd();
         
         this.service.addRequester(notMember1);
+    }
+    
+    // TODO add documentation
+    @Test
+    public void testRemoveTarget() throws Exception {
+    	setUpAllowListWithTargetListBeforeRemove();
+    	
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isTargetAuthorized(notMember1));
+        Assert.assertFalse(this.service.isTargetAuthorized(""));
+        
+        this.service.removeTarget(memberAuthorizedAsTarget);
+        
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, targetsListAfterRemove);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+        
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isTargetAuthorized(notMember1));
+        Assert.assertFalse(this.service.isTargetAuthorized(""));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownTargetMustFail() throws Exception {
+    	setUpAllowListWithTargetListBeforeRemove();
+    	
+        this.service.removeTarget(memberAuthorizedAsRequester);
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownProviderFromTargetsMustFail() throws Exception {
+    	setUpAllowListWithTargetListBeforeRemove();
+    	
+        this.service.removeTarget(notMember1);
+    }
+    
+    // TODO add documentation
+    @Test
+    public void testRemoveRequester() throws Exception {
+    	setUpAllowListWithRequestersListBeforeRemove();
+    	
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
+        Assert.assertFalse(this.service.isRequesterAuthorized(""));
+        
+        this.service.removeRequester(memberAuthorizedAsRequester);
+        
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, requestersListAfterRemove);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+        
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
+        Assert.assertFalse(this.service.isRequesterAuthorized(""));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownRequesterMustFail() throws Exception {
+    	setUpAllowListWithRequestersListBeforeRemove();
+    	
+        this.service.removeRequester(memberAuthorizedAsTarget);
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownProviderFromRequestersMustFail() throws Exception {
+    	setUpAllowListWithRequestersListBeforeRemove();
+    	
+        this.service.removeRequester(notMember1);
     }
     
     private void setUpAllowList(String membersListString, String allowedRequestersListString, String allowedTargetsListString) throws ConfigurationErrorException {
@@ -253,11 +342,19 @@ public class AllowListTest {
         setUpAllowList(membersListString, emptyAllowedRequestersList, allowedTargetsList);
     }
     
-    private void setUpAllowListWithTargetListToBeUpdated() throws ConfigurationErrorException {
-    	setUpAllowList(membersListString, allowedRequestersList, targetsListToBeUpdated);
+    private void setUpAllowListWithTargetListBeforeAdd() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, allowedRequestersList, targetsListBeforeAdd);
     }
     
-    private void setUpAllowListWithRequesterListToBeUpdated() throws ConfigurationErrorException {
-    	setUpAllowList(membersListString, requestersListToBeUpdated, allowedTargetsList);
+    private void setUpAllowListWithRequesterListBeforeAdd() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, requestersListBeforeAdd, allowedTargetsList);
+    }
+    
+    private void setUpAllowListWithTargetListBeforeRemove() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, allowedRequestersList, targetsListBeforeRemove);
+    }
+    
+    private void setUpAllowListWithRequestersListBeforeRemove() throws ConfigurationErrorException {
+    	setUpAllowList(membersListString, requestersListBeforeRemove, allowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/AllowListTest.java
@@ -175,6 +175,60 @@ public class AllowListTest {
     
     // TODO add documentation
     @Test
+    public void testRemoveMember() throws Exception {
+    	setUpAllowListWithDefaultLists();
+    	
+    	List<String> membersId = this.service.listMembers();
+    	
+        // verify before removing member
+        Assert.assertEquals(3, membersId.size());
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsRequester));
+        Assert.assertTrue(membersId.contains(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsRequester));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
+    	
+    	this.service.removeMember(memberAuthorizedAsRequesterAndTarget);
+    	
+    	// verify configuration is update
+    	String updatedMembersListString = String.join(",", memberAuthorizedAsRequester, memberAuthorizedAsTarget);
+    	String updatedRequestersList = memberAuthorizedAsRequester;
+    	String updatedTargetsList = memberAuthorizedAsTarget;
+    	
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, updatedTargetsList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
+    			updatedRequestersList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, updatedMembersListString);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+    	
+        List<String> updateMembersId = this.service.listMembers();
+
+        // verify after removing member
+        Assert.assertEquals(2, membersId.size());
+        Assert.assertTrue(updateMembersId.contains(memberAuthorizedAsRequester));
+        Assert.assertTrue(updateMembersId.contains(memberAuthorizedAsTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberAuthorizedAsTarget));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingNotKnownMemberMustFail() throws ConfigurationErrorException {
+    	setUpAllowListWithDefaultLists();
+    	
+    	this.service.removeMember(notMember1);
+    }
+    
+    // TODO add documentation
+    @Test
     public void testAddTarget() throws Exception {
     	setUpAllowListWithTargetListBeforeAdd();
     	

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -176,7 +176,7 @@ public class BlockListTest {
     // TODO add documentation
     @Test
     public void testAddTarget() throws Exception {
-    	setUpBlockListWithTargetListToBeUpdated();
+    	setUpBlockListWithTargetListBeforeAdd();
     	
         Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
         Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
@@ -200,15 +200,29 @@ public class BlockListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddNotKnownTargetMustFail() throws Exception {
-    	setUpBlockListWithTargetListToBeUpdated();
+    	setUpBlockListWithTargetListBeforeAdd();
     	
         this.service.addTarget(notMember1);
+    }
+    
+    // TODO add documentation   
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingDuplicateTargetMustFail() throws Exception {
+    	setUpBlockListWithTargetListBeforeAdd();
+	    
+    	try {	
+	        this.service.addTarget(memberNotAuthorizedAsTarget);
+		} catch (Exception e) {
+			Assert.fail("This call should not throw exception.");
+		}
+        
+        this.service.addTarget(memberNotAuthorizedAsTarget);
     }
     
     // TODO add documentation
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
-    	setUpBlockListWithRequesterListToBeUpdated();
+    	setUpBlockListWithRequesterListBeforeAdd();
     	
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
         Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
@@ -232,9 +246,23 @@ public class BlockListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
-    	setUpBlockListWithRequesterListToBeUpdated();
+    	setUpBlockListWithRequesterListBeforeAdd();
         
         this.service.addRequester(notMember1);
+    }
+    
+    // TODO add documentation   
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingDuplicateRequesterMustFail() throws Exception {
+    	setUpBlockListWithRequesterListBeforeAdd();
+	    
+    	try {   
+	        this.service.addRequester(memberNotAuthorizedAsRequester);
+		} catch (Exception e) {
+			Assert.fail("This call should not throw exception.");
+		}
+        
+        this.service.addRequester(memberNotAuthorizedAsRequester);
     }
 
     // TODO add documentation
@@ -341,11 +369,11 @@ public class BlockListTest {
         setUpBlockList(membersListString, emptyNotAllowedRequestersList, notAllowedTargetsList);
     }
     
-    private void setUpBlockListWithTargetListToBeUpdated() throws ConfigurationErrorException {
+    private void setUpBlockListWithTargetListBeforeAdd() throws ConfigurationErrorException {
     	setUpBlockList(membersListString, notAllowedRequestersList, targetsListBeforeAdd);
     }
     
-    private void setUpBlockListWithRequesterListToBeUpdated() throws ConfigurationErrorException {
+    private void setUpBlockListWithRequesterListBeforeAdd() throws ConfigurationErrorException {
     	setUpBlockList(membersListString, requestersListBeforeAdd, notAllowedTargetsList);
     }
     

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -38,13 +38,21 @@ public class BlockListTest {
     private String updatedMembersListString = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
             memberNotAuthorizedAsRequester, memberNotAuthorizedAsTarget, newMember);
     
-    private String targetsListToBeUpdated = memberNotAuthorizedAsRequesterAndTarget;
-    private String updatedTargetsList = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
+    private String targetsListBeforeAdd = memberNotAuthorizedAsRequesterAndTarget;
+    private String targetsListAfterAdd = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
     									memberNotAuthorizedAsTarget);
     
-    private String requestersListToBeUpdated = memberNotAuthorizedAsRequesterAndTarget;
-    private String updatedRequestersList = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
+    private String requestersListBeforeAdd = memberNotAuthorizedAsRequesterAndTarget;
+    private String requestersListAfterAdd = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
     									memberNotAuthorizedAsRequester);
+    
+	private String targetsListBeforeRemove = String.join(",", memberNotAuthorizedAsTarget,
+										memberNotAuthorizedAsRequesterAndTarget);
+	private String targetsListAfterRemove = memberNotAuthorizedAsRequesterAndTarget;
+
+	private String requestersListBeforeRemove = String.join(",", memberNotAuthorizedAsRequester,
+										memberNotAuthorizedAsRequesterAndTarget);
+	private String requestersListAfterRemove = memberNotAuthorizedAsRequesterAndTarget;
     
     private String emptyNotAllowedTargetsList = "";
     private String emptyNotAllowedRequestersList = "";
@@ -179,7 +187,7 @@ public class BlockListTest {
         this.service.addTarget(memberNotAuthorizedAsTarget);
         
     	// verify configuration is update
-    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, updatedTargetsList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, targetsListAfterAdd);
     	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
         
         Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
@@ -211,7 +219,7 @@ public class BlockListTest {
         this.service.addRequester(memberNotAuthorizedAsRequester);
         
     	// verify configuration is update
-    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, updatedRequestersList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, requestersListAfterAdd);
     	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
         
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
@@ -227,6 +235,86 @@ public class BlockListTest {
     	setUpBlockListWithRequesterListToBeUpdated();
         
         this.service.addRequester(notMember1);
+    }
+
+    // TODO add documentation
+    @Test
+    public void testRemoveTarget() throws Exception {
+    	setUpBlockListWithTargetListBeforeRemove();
+    	
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isTargetAuthorized(notMember1));
+        Assert.assertFalse(this.service.isTargetAuthorized(""));
+        
+        this.service.removeTarget(memberNotAuthorizedAsTarget);
+        
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, targetsListAfterRemove);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+        
+        Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isTargetAuthorized(notMember1));
+        Assert.assertFalse(this.service.isTargetAuthorized(""));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownTargetMustFail() throws Exception {
+    	setUpBlockListWithTargetListBeforeRemove();
+    	
+        this.service.removeTarget(memberNotAuthorizedAsRequester);
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownProviderFromTargetsMustFail() throws Exception {
+    	setUpBlockListWithTargetListBeforeRemove();
+    	
+        this.service.removeTarget(notMember1);
+    }
+    
+    // TODO add documentation
+    @Test
+    public void testRemoveRequester() throws Exception {
+    	setUpBlockListWithRequestersListBeforeRemove();
+    	
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
+        Assert.assertFalse(this.service.isRequesterAuthorized(""));
+        
+        this.service.removeRequester(memberNotAuthorizedAsRequester);
+        
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, requestersListAfterRemove);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+        
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(notMember1));
+        Assert.assertFalse(this.service.isRequesterAuthorized(""));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownRequesterMustFail() throws Exception {
+    	setUpBlockListWithRequestersListBeforeRemove();
+    	
+        this.service.removeRequester(memberNotAuthorizedAsTarget);
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingUnknownProviderFromRequestersMustFail() throws Exception {
+    	setUpBlockListWithRequestersListBeforeRemove();
+    	
+        this.service.removeRequester(notMember1);
     }
     
     private void setUpBlockList(String membersListString, String notAllowedRequestersListString, String notAllowedTargetsListString) throws ConfigurationErrorException {
@@ -254,10 +342,18 @@ public class BlockListTest {
     }
     
     private void setUpBlockListWithTargetListToBeUpdated() throws ConfigurationErrorException {
-    	setUpBlockList(membersListString, notAllowedRequestersList, targetsListToBeUpdated);
+    	setUpBlockList(membersListString, notAllowedRequestersList, targetsListBeforeAdd);
     }
     
     private void setUpBlockListWithRequesterListToBeUpdated() throws ConfigurationErrorException {
-    	setUpBlockList(membersListString, requestersListToBeUpdated, notAllowedTargetsList);
+    	setUpBlockList(membersListString, requestersListBeforeAdd, notAllowedTargetsList);
+    }
+    
+    private void setUpBlockListWithTargetListBeforeRemove() throws ConfigurationErrorException {
+    	setUpBlockList(membersListString, notAllowedRequestersList, targetsListBeforeRemove);
+    }
+    
+    private void setUpBlockListWithRequestersListBeforeRemove() throws ConfigurationErrorException {
+    	setUpBlockList(membersListString, requestersListBeforeRemove, notAllowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -175,6 +175,60 @@ public class BlockListTest {
     
     // TODO add documentation
     @Test
+    public void testRemoveMember() throws Exception {
+    	setUpBlockListWithDefaultLists();
+    	
+        String updatedMembersListString = String.join(",", memberNotAuthorizedAsRequester, memberNotAuthorizedAsTarget);
+        String updatedRequestersList = memberNotAuthorizedAsRequester;
+        String updatedTargetsList = memberNotAuthorizedAsTarget;
+    	
+    	List<String> membersId = this.service.listMembers();
+    	
+        // verify before removing member
+        Assert.assertEquals(3, membersId.size());
+        Assert.assertTrue(membersId.contains(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(membersId.contains(memberNotAuthorizedAsRequester));
+        Assert.assertTrue(membersId.contains(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
+    	
+    	this.service.removeMember(memberNotAuthorizedAsRequesterAndTarget);
+    	
+    	// verify configuration is update
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY, updatedTargetsList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY, 
+    			updatedRequestersList);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, updatedMembersListString);
+    	Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
+    	
+        List<String> updateMembersId = this.service.listMembers();
+
+        // verify after removing member
+        Assert.assertEquals(2, membersId.size());
+        Assert.assertTrue(updateMembersId.contains(memberNotAuthorizedAsRequester));
+        Assert.assertTrue(updateMembersId.contains(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
+        Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
+        Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
+        Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
+    }
+    
+    // TODO add documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testRemovingNotKnownMemberMustFail() throws ConfigurationErrorException {
+    	setUpBlockListWithDefaultLists();
+    	
+    	this.service.removeMember(notMember1);
+    }
+    
+    // TODO add documentation
+    @Test
     public void testAddTarget() throws Exception {
     	setUpBlockListWithTargetListBeforeAdd();
     	

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -210,6 +210,34 @@ public class BlockListTest {
     }
     
     // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingAlreadyKnownProviderMustFail() throws ConfigurationErrorException {
+        setUpBlockListWithDefaultLists();
+        
+        try {
+            this.service.addMember(new ProviderPermission(newTargetMember, true, false));
+        } catch (Exception e) {
+            Assert.fail("This call should not fail.");
+        }
+        
+        this.service.addMember(new ProviderPermission(newTargetMember, true, false));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testAddingNoTargetAndNoRequesterMemberMustFail() throws ConfigurationErrorException {
+        setUpBlockListWithDefaultLists();
+        
+        this.service.addMember(new ProviderPermission(newTargetMember, false, false));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testConstructorMustCheckIfAllMembersHavePermissions( ) throws ConfigurationErrorException {
+        setUpBlockListWithProviderWithNoPermission();
+    }
+    
+    // TODO documentation
     @Test
     public void testUpdateMember() throws Exception {
         setUpBlockListWithDefaultLists();
@@ -233,6 +261,14 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
         Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
+    }
+    
+    // TODO documentation
+    @Test(expected = ConfigurationErrorException.class)
+    public void testUpdatingNotKnownMemberMustFail() throws ConfigurationErrorException {
+        setUpBlockListWithDefaultLists();
+        
+        this.service.updateMember(new ProviderPermission(notMember1, false, true));
     }
     
     // test case: When invoking the removeMember method, it must remove the given provider correctly
@@ -309,10 +345,17 @@ public class BlockListTest {
     }
     
     private void setUpBlockListWithEmptyNotAllowedTargetsList() throws ConfigurationErrorException {
+     // TODO explain
         setUpBlockList(membersListString, membersListString, emptyNotAllowedTargetsList);
     }
     
     private void setUpBlockListWithEmptyNotAllowedRequestersList() throws ConfigurationErrorException {
+     // TODO explain
         setUpBlockList(membersListString, emptyNotAllowedRequestersList, membersListString);
+    }
+    
+    private void setUpBlockListWithProviderWithNoPermission() throws ConfigurationErrorException {
+        // TODO explain
+        setUpBlockList(membersListString, emptyNotAllowedRequestersList, notAllowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -143,7 +143,9 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addMember method, it must add the given provider correctly, 
+    // so that the change is reflected on the return value of the method listMembers. Also, 
+    // the configuration file must be updated.
     @Test
     public void testAddMember() throws Exception {
     	setUpBlockListWithDefaultLists();
@@ -173,7 +175,9 @@ public class BlockListTest {
         Assert.assertTrue(updateMembersId.contains(newMember));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeMember method, it must remove the given provider correctly
+    // from all internal lists, so that the change is reflected on the return value of the methods listMembers, 
+    // isTargetAuthorized and isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveMember() throws Exception {
     	setUpBlockListWithDefaultLists();
@@ -219,7 +223,8 @@ public class BlockListTest {
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeMember method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingNotKnownMemberMustFail() throws ConfigurationErrorException {
     	setUpBlockListWithDefaultLists();
@@ -227,7 +232,9 @@ public class BlockListTest {
     	this.service.removeMember(notMember1);
     }
     
-    // TODO add documentation
+    // test case: When invoking the addTarget method, it must add the given provider 
+    // as target correctly, so that the change is reflected on the return value of the 
+    // method isTargetAuthorized. Also, the configuration file must be updated.
     @Test
     public void testAddTarget() throws Exception {
     	setUpBlockListWithTargetListBeforeAdd();
@@ -251,7 +258,8 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isTargetAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addTarget method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testAddNotKnownTargetMustFail() throws Exception {
     	setUpBlockListWithTargetListBeforeAdd();
@@ -259,7 +267,8 @@ public class BlockListTest {
         this.service.addTarget(notMember1);
     }
     
-    // TODO add documentation   
+    // test case: When invoking the addTarget method with a provider which is already 
+    // in the target providers list, it must throw a ConfigurationErrorException.   
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingDuplicateTargetMustFail() throws Exception {
     	setUpBlockListWithTargetListBeforeAdd();
@@ -273,7 +282,9 @@ public class BlockListTest {
         this.service.addTarget(memberNotAuthorizedAsTarget);
     }
     
-    // TODO add documentation
+    // test case: When invoking the addRequester method, it must add the given provider 
+    // as requester correctly, so that the change is reflected on the return value of the 
+    // method isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
     	setUpBlockListWithRequesterListBeforeAdd();
@@ -297,7 +308,8 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the addRequester method with a provider which is not on 
+    // the memberList, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
     	setUpBlockListWithRequesterListBeforeAdd();
@@ -305,7 +317,8 @@ public class BlockListTest {
         this.service.addRequester(notMember1);
     }
     
-    // TODO add documentation   
+    // test case: When invoking the addRequester method with a provider which is already 
+    // in the requester providers list, it must throw a ConfigurationErrorException.   
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingDuplicateRequesterMustFail() throws Exception {
     	setUpBlockListWithRequesterListBeforeAdd();
@@ -319,7 +332,9 @@ public class BlockListTest {
         this.service.addRequester(memberNotAuthorizedAsRequester);
     }
 
-    // TODO add documentation
+    // test case: When invoking the removeTarget method, it must remove the given provider 
+    // from the targets list correctly, so that the change is reflected on the return value of the 
+    // method isTargetAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveTarget() throws Exception {
     	setUpBlockListWithTargetListBeforeRemove();
@@ -343,7 +358,8 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isTargetAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeTarget method with a provider 
+    // which is not a target, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownTargetMustFail() throws Exception {
     	setUpBlockListWithTargetListBeforeRemove();
@@ -351,7 +367,8 @@ public class BlockListTest {
         this.service.removeTarget(memberNotAuthorizedAsRequester);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeTarget with an unknown provider,
+    // it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownProviderFromTargetsMustFail() throws Exception {
     	setUpBlockListWithTargetListBeforeRemove();
@@ -359,7 +376,9 @@ public class BlockListTest {
         this.service.removeTarget(notMember1);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester method, it must remove the given provider 
+    // from the requesters list correctly, so that the change is reflected on the return value of the 
+    // method isRequesterAuthorized. Also, the configuration file must be updated.
     @Test
     public void testRemoveRequester() throws Exception {
     	setUpBlockListWithRequestersListBeforeRemove();
@@ -383,7 +402,8 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(""));
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester method with a provider 
+    // which is not a requester, it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownRequesterMustFail() throws Exception {
     	setUpBlockListWithRequestersListBeforeRemove();
@@ -391,7 +411,8 @@ public class BlockListTest {
         this.service.removeRequester(memberNotAuthorizedAsTarget);
     }
     
-    // TODO add documentation
+    // test case: When invoking the removeRequester with an unknown provider,
+    // it must throw a ConfigurationErrorException.
     @Test(expected = ConfigurationErrorException.class)
     public void testRemovingUnknownProviderFromRequestersMustFail() throws Exception {
     	setUpBlockListWithRequestersListBeforeRemove();

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -49,6 +49,8 @@ public class BlockListTest {
     private String emptyNotAllowedTargetsList = "";
     private String emptyNotAllowedRequestersList = "";
 
+    private PropertiesHolder propertiesHolder;
+    
     // test case: When invoking the listMembers method from an instance created with
     // the MembershipService class constructor with a valid parameter, it must list
     // the configured membership in the file passed by parameter.
@@ -136,15 +138,7 @@ public class BlockListTest {
     // TODO add documentation
     @Test
     public void testAddMember() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new BlockList();
+    	setUpBlockListWithDefaultLists();
     	
     	List<String> membersId = this.service.listMembers();
     	
@@ -174,15 +168,7 @@ public class BlockListTest {
     // TODO add documentation
     @Test
     public void testAddTarget() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(targetsListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new BlockList();
+    	setUpBlockListWithTargetListToBeUpdated();
     	
         Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
         Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));
@@ -206,31 +192,15 @@ public class BlockListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddNotKnownTargetMustFail() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedRequestersList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(targetsListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+    	setUpBlockListWithTargetListToBeUpdated();
     	
-    	this.service = new BlockList();
-        
         this.service.addTarget(notMember1);
     }
     
     // TODO add documentation
     @Test
     public void testAddRequester() throws ConfigurationErrorException {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(requestersListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new BlockList();
+    	setUpBlockListWithRequesterListToBeUpdated();
     	
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
         Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequesterAndTarget));
@@ -254,27 +224,19 @@ public class BlockListTest {
     // TODO add documentation
     @Test(expected = ConfigurationErrorException.class)
     public void testAddingNotKnownRequesterMustFail() throws Exception {
-        PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(requestersListToBeUpdated).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedTargetsList).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
-        
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
-    	
-    	this.service = new BlockList();
+    	setUpBlockListWithRequesterListToBeUpdated();
         
         this.service.addRequester(notMember1);
     }
     
     private void setUpBlockList(String membersListString, String notAllowedRequestersListString, String notAllowedTargetsListString) throws ConfigurationErrorException {
         PowerMockito.mockStatic(PropertiesHolder.class);
-        PropertiesHolder propertiesHolder = Mockito.mock(PropertiesHolder.class);
-        Mockito.doReturn(membersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedRequestersListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
-        Mockito.doReturn(notAllowedTargetsListString).when(propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
+        this.propertiesHolder = Mockito.mock(PropertiesHolder.class);
+        Mockito.doReturn(membersListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY);
+        Mockito.doReturn(notAllowedRequestersListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.REQUESTER_MEMBERS_LIST_KEY);
+        Mockito.doReturn(notAllowedTargetsListString).when(this.propertiesHolder).getProperty(ConfigurationPropertyKeys.TARGET_MEMBERS_LIST_KEY);
         
-        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(propertiesHolder);
+        BDDMockito.given(PropertiesHolder.getInstance()).willReturn(this.propertiesHolder);
         
         this.service = new BlockList();
     }
@@ -289,5 +251,13 @@ public class BlockListTest {
     
     private void setUpBlockListWithEmptyNotAllowedRequestersList() throws ConfigurationErrorException {
         setUpBlockList(membersListString, emptyNotAllowedRequestersList, notAllowedTargetsList);
+    }
+    
+    private void setUpBlockListWithTargetListToBeUpdated() throws ConfigurationErrorException {
+    	setUpBlockList(membersListString, notAllowedRequestersList, targetsListToBeUpdated);
+    }
+    
+    private void setUpBlockListWithRequesterListToBeUpdated() throws ConfigurationErrorException {
+    	setUpBlockList(membersListString, requestersListToBeUpdated, notAllowedTargetsList);
     }
 }

--- a/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
+++ b/src/test/java/cloud/fogbow/ms/core/service/BlockListTest.java
@@ -12,6 +12,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import cloud.fogbow.common.exceptions.ConfigurationErrorException;
+import cloud.fogbow.ms.api.parameters.ProviderPermission;
 import cloud.fogbow.ms.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ms.core.MembershipService;
 import cloud.fogbow.ms.core.PropertiesHolder;
@@ -144,7 +145,7 @@ public class BlockListTest {
         Assert.assertFalse(membersId.contains(newRequesterMember));
         Assert.assertFalse(membersId.contains(newTargetAndRequesterMember));
         
-        this.service.addMember(newTargetMember, true, false);
+        this.service.addMember(new ProviderPermission(newTargetMember, true, false));
     
         String firstUpdateMembersListString = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
                 memberNotAuthorizedAsRequester, memberNotAuthorizedAsTarget, 
@@ -154,7 +155,7 @@ public class BlockListTest {
         Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, firstUpdateMembersListString);
         Mockito.verify(propertiesHolder, Mockito.times(1)).updatePropertiesFile();
         
-        this.service.addMember(newRequesterMember, false, true);
+        this.service.addMember(new ProviderPermission(newRequesterMember, false, true));
 
         String secondUpdatedMembersListString = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
                 memberNotAuthorizedAsRequester, memberNotAuthorizedAsTarget, 
@@ -164,7 +165,7 @@ public class BlockListTest {
         Mockito.verify(propertiesHolder, Mockito.times(1)).setProperty(ConfigurationPropertyKeys.MEMBERS_LIST_KEY, secondUpdatedMembersListString);
         Mockito.verify(propertiesHolder, Mockito.times(2)).updatePropertiesFile();
 
-        this.service.addMember(newTargetAndRequesterMember, true, true);
+        this.service.addMember(new ProviderPermission(newTargetAndRequesterMember, true, true));
         
         String thirdUpdatedMembersListString = String.join(",", memberNotAuthorizedAsRequesterAndTarget, 
                 memberNotAuthorizedAsRequester, memberNotAuthorizedAsTarget, 
@@ -222,8 +223,8 @@ public class BlockListTest {
         Assert.assertFalse(this.service.isRequesterAuthorized(memberNotAuthorizedAsRequester));
         Assert.assertTrue(this.service.isRequesterAuthorized(memberNotAuthorizedAsTarget));
         
-        this.service.updateMember(memberNotAuthorizedAsTarget, false, true);
-        this.service.updateMember(memberNotAuthorizedAsRequester, true, false);
+        this.service.updateMember(new ProviderPermission(memberNotAuthorizedAsTarget, false, true));
+        this.service.updateMember(new ProviderPermission(memberNotAuthorizedAsRequester, true, false));
         
         Assert.assertTrue(this.service.isTargetAuthorized(memberNotAuthorizedAsTarget));
         Assert.assertFalse(this.service.isTargetAuthorized(memberNotAuthorizedAsRequesterAndTarget));


### PR DESCRIPTION
This PR adds several administrator-only operations, such as reload configuration and add/remove providers. Authorization is performed by a special AuthorizationPlugin which reads a list of administrator ids from the configuration file. The list of new operations follows:

- reload
- addProvider
- removeProvider
- addTargetProvider
- removeTargetProvider
- addRequesterProvider
- removeRequesterProvider

Requires https://github.com/fogbow/common/pull/276